### PR TITLE
[FEAT/#28] 임시 저장 후 이미지 공유 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -46,6 +46,16 @@
             android:exported="false"
             android:screenOrientation="portrait" />
 
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
+
     </application>
 
 </manifest>

--- a/presentation/src/main/res/xml/file_paths.xml
+++ b/presentation/src/main/res/xml/file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <cache-path name="images" path="." />
+</paths>


### PR DESCRIPTION
- closed #28

## *⛳️ Work Description*
- 이미지 기기 저장 안하고 공유 구현
- 이미지뷰의 이미지를 가져와 비트맵 전환 후 FileProvider로 임시 파일 저장 후 URI 값 가져와 공유

## *📸 Screenshot*
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<img src="https://github.com/Genti2024/Genti-Android/assets/97405341/8244aaae-3cc3-4ce5-ac29-72db89fb0b3c" width=270 /> 

