### PR TITLE
[REFACTOR/#233] 생성 결과뷰 Compose 마이그레이션

### DIFF
--- a/core/common/src/main/java/kr/genti/common/manager/AmplitudeManager.kt
+++ b/core/common/src/main/java/kr/genti/common/manager/AmplitudeManager.kt
@@ -74,7 +74,4 @@ object AmplitudeManager {
     const val PROPERTY_PAGE = "page_name"
     const val PROPERTY_BTN = "button_name"
     const val PROPERTY_TYPE = "picdone_type"
-
-    const val TYPE_ORIGINAL = "original"
-    const val TYPE_PARENT = "parents"
 }

--- a/core/designsystem/src/main/java/kr/genti/designsystem/component/dialog/GentiRatingDialog.kt
+++ b/core/designsystem/src/main/java/kr/genti/designsystem/component/dialog/GentiRatingDialog.kt
@@ -1,0 +1,122 @@
+package kr.genti.designsystem.component.dialog
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import kr.genti.common.extension.noRippleClickable
+import kr.genti.core.designsystem.R
+import kr.genti.designsystem.component.button.GentiButton
+import kr.genti.designsystem.component.button.GentiGradationButton
+import kr.genti.designsystem.component.item.GentiRatingBar
+import kr.genti.designsystem.theme.GentiTheme
+import kr.genti.designsystem.theme.Gray
+import kr.genti.designsystem.theme.Transparent50
+import kr.genti.designsystem.theme.White
+import kr.genti.designsystem.theme.White80
+
+@Composable
+fun GentiRatingDialog(
+    modifier: Modifier = Modifier,
+    @StringRes titleRes: Int = R.string.finished_rating_tv_title,
+    @StringRes subtitleRes: Int = R.string.finished_rating_tv_subtitle,
+    rating: Int = 5,
+    onRatingChange: (Int) -> Unit = {},
+    onSubmitBtnClick: () -> Unit = {},
+    onSkipBtnClick: () -> Unit = {},
+    onDismissRequest: () -> Unit = {},
+) {
+    Dialog(
+        onDismissRequest = onDismissRequest,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Box(
+            modifier = modifier
+                .fillMaxSize()
+                .background(Transparent50)
+                .noRippleClickable { onDismissRequest() }
+                .padding(16.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Column(
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = modifier
+                    .fillMaxWidth()
+                    .background(color = Gray, shape = RoundedCornerShape(16.dp))
+                    .padding(16.dp)
+            ) {
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Text(
+                    text = stringResource(titleRes),
+                    style = GentiTheme.typography.title,
+                    color = White,
+                    textAlign = TextAlign.Center,
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Text(
+                    text = stringResource(subtitleRes),
+                    style = GentiTheme.typography.body2,
+                    color = White80,
+                    textAlign = TextAlign.Center,
+                )
+
+                Spacer(modifier = Modifier.height(20.dp))
+
+                GentiRatingBar(
+                    rating = rating,
+                    onRatingChanged = onRatingChange,
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    GentiButton(
+                        textRes = R.string.finished_rating_tv_btn_skip,
+                        onClick = onSkipBtnClick,
+                        btnColor = White,
+                        modifier = Modifier.weight(1f)
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    GentiGradationButton(
+                        textRes = R.string.signup_btn_submit,
+                        onClick = onSubmitBtnClick,
+                        modifier = Modifier.weight(1f)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun GentiRatingDialogPreview() {
+    GentiTheme {
+        GentiRatingDialog()
+    }
+}

--- a/core/designsystem/src/main/java/kr/genti/designsystem/component/dialog/GentiRatingDialog.kt
+++ b/core/designsystem/src/main/java/kr/genti/designsystem/component/dialog/GentiRatingDialog.kt
@@ -30,7 +30,6 @@ import kr.genti.designsystem.component.button.GentiGradationButton
 import kr.genti.designsystem.component.item.GentiRatingBar
 import kr.genti.designsystem.theme.GentiTheme
 import kr.genti.designsystem.theme.Gray
-import kr.genti.designsystem.theme.Transparent50
 import kr.genti.designsystem.theme.White
 import kr.genti.designsystem.theme.White80
 
@@ -52,7 +51,6 @@ fun GentiRatingDialog(
         Box(
             modifier = modifier
                 .fillMaxSize()
-                .background(Transparent50)
                 .noRippleClickable { onDismissRequest() }
                 .padding(16.dp),
             contentAlignment = Alignment.Center

--- a/core/designsystem/src/main/java/kr/genti/designsystem/component/dialog/GentiTextFieldDialog.kt
+++ b/core/designsystem/src/main/java/kr/genti/designsystem/component/dialog/GentiTextFieldDialog.kt
@@ -35,7 +35,6 @@ import kr.genti.designsystem.theme.Black
 import kr.genti.designsystem.theme.GentiTheme
 import kr.genti.designsystem.theme.Gray
 import kr.genti.designsystem.theme.Transparent
-import kr.genti.designsystem.theme.Transparent50
 import kr.genti.designsystem.theme.White
 import kr.genti.designsystem.theme.White40
 import kr.genti.designsystem.theme.White80
@@ -67,7 +66,6 @@ fun GentiTextFieldDialog(
         Box(
             modifier = modifier
                 .fillMaxSize()
-                .background(Transparent50)
                 .imePadding()
                 .noRippleClickable { focusManager.clearFocus() }
                 .padding(horizontal = 16.dp),

--- a/core/designsystem/src/main/java/kr/genti/designsystem/component/dialog/GentiTextFieldDialog.kt
+++ b/core/designsystem/src/main/java/kr/genti/designsystem/component/dialog/GentiTextFieldDialog.kt
@@ -11,9 +11,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -23,12 +21,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import kr.genti.common.extension.noRippleClickable
 import kr.genti.core.designsystem.R
 import kr.genti.designsystem.component.button.GentiButton
 import kr.genti.designsystem.theme.Black
@@ -57,13 +57,19 @@ fun GentiTextFieldDialog(
 ) {
     Dialog(
         onDismissRequest = onDismissRequest,
-        properties = DialogProperties(usePlatformDefaultWidth = false, decorFitsSystemWindows = false),
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false,
+            decorFitsSystemWindows = false
+        ),
     ) {
+        val focusManager = LocalFocusManager.current
+
         Box(
             modifier = modifier
                 .fillMaxSize()
                 .background(Transparent50)
                 .imePadding()
+                .noRippleClickable { focusManager.clearFocus() }
                 .padding(horizontal = 16.dp),
             contentAlignment = Alignment.Center
         ) {

--- a/core/designsystem/src/main/java/kr/genti/designsystem/component/dialog/GentiTextFieldDialog.kt
+++ b/core/designsystem/src/main/java/kr/genti/designsystem/component/dialog/GentiTextFieldDialog.kt
@@ -1,0 +1,169 @@
+package kr.genti.designsystem.component.dialog
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import kr.genti.core.designsystem.R
+import kr.genti.designsystem.component.button.GentiButton
+import kr.genti.designsystem.theme.Black
+import kr.genti.designsystem.theme.GentiTheme
+import kr.genti.designsystem.theme.Gray
+import kr.genti.designsystem.theme.Transparent
+import kr.genti.designsystem.theme.Transparent50
+import kr.genti.designsystem.theme.White
+import kr.genti.designsystem.theme.White40
+import kr.genti.designsystem.theme.White80
+
+@Composable
+fun GentiTextFieldDialog(
+    modifier: Modifier = Modifier,
+    @StringRes inputTitleRes: Int = R.string.finished_error_input_tv_title,
+    @StringRes inputSubtitleRes: Int = R.string.finished_error_input_tv_subtitle,
+    @StringRes inputHintRes: Int = R.string.finished_error_input_tv_hint,
+    @StringRes outputTitleRes: Int = R.string.finished_error_output_tv_title,
+    @StringRes outputSubtitleRes: Int = R.string.finished_error_output_tv_subtitle,
+    text: String = "",
+    isSubmitted: Boolean = false,
+    onTextChange: (String) -> Unit = {},
+    onSubmitBtnClick: () -> Unit = {},
+    onSubmitFinishBtnClick: () -> Unit = {},
+    onDismissRequest: () -> Unit = {},
+) {
+    Dialog(
+        onDismissRequest = onDismissRequest,
+        properties = DialogProperties(usePlatformDefaultWidth = false, decorFitsSystemWindows = false),
+    ) {
+        Box(
+            modifier = modifier
+                .fillMaxSize()
+                .background(Transparent50)
+                .imePadding()
+                .padding(horizontal = 16.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Column(
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = modifier
+                    .wrapContentSize()
+                    .background(color = Gray, shape = RoundedCornerShape(16.dp))
+                    .padding(16.dp)
+            ) {
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Text(
+                    text = stringResource(if (!isSubmitted) inputTitleRes else outputTitleRes),
+                    style = GentiTheme.typography.title,
+                    color = White,
+                    textAlign = TextAlign.Center,
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Text(
+                    text = stringResource(if (!isSubmitted) inputSubtitleRes else outputSubtitleRes),
+                    style = GentiTheme.typography.body2,
+                    color = White80,
+                    textAlign = TextAlign.Center,
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                if (!isSubmitted) {
+                    BasicTextField(
+                        value = text,
+                        onValueChange = { newValue -> onTextChange(newValue) },
+                        textStyle = GentiTheme.typography.body2,
+                        cursorBrush = SolidColor(Transparent),
+                        decorationBox = { innerTextField ->
+                            Box {
+                                if (text.isEmpty()) {
+                                    Text(
+                                        text = stringResource(id = inputHintRes),
+                                        style = GentiTheme.typography.body2,
+                                        color = White40
+                                    )
+                                }
+                                innerTextField()
+                            }
+                        },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(color = Black, shape = RoundedCornerShape(10.dp))
+                            .padding(16.dp)
+                    )
+
+                    Spacer(modifier = Modifier.height(18.dp))
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        GentiButton(
+                            textRes = R.string.btn_close,
+                            onClick = onDismissRequest,
+                            btnColor = White,
+                            modifier = Modifier.weight(1f)
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        GentiButton(
+                            textRes = R.string.finished_error_input_btn_submit,
+                            onClick = onSubmitBtnClick,
+                            isActive = text.isNotEmpty(),
+                            modifier = Modifier.weight(1f)
+                        )
+                    }
+                } else {
+                    GentiButton(
+                        textRes = R.string.btn_close,
+                        onClick = onSubmitFinishBtnClick,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun GentiTextFieldDialogInputPreview() {
+    GentiTheme {
+        GentiTextFieldDialog()
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun GentiTextFieldDialogOutputPreview() {
+    GentiTheme {
+        GentiTextFieldDialog(
+            isSubmitted = true
+        )
+    }
+}

--- a/core/designsystem/src/main/java/kr/genti/designsystem/component/item/GentiCheckedText.kt
+++ b/core/designsystem/src/main/java/kr/genti/designsystem/component/item/GentiCheckedText.kt
@@ -36,7 +36,8 @@ fun GentiCheckedText(
         Icon(
             imageVector = ImageVector.vectorResource(id = R.drawable.ic_check),
             contentDescription = null,
-            tint = GentiGreen
+            tint = GentiGreen,
+            modifier = Modifier.padding(top = 1.dp)
         )
 
         Spacer(modifier = Modifier.width(2.dp))

--- a/core/designsystem/src/main/java/kr/genti/designsystem/component/item/GentiRatingBar.kt
+++ b/core/designsystem/src/main/java/kr/genti/designsystem/component/item/GentiRatingBar.kt
@@ -1,0 +1,38 @@
+package kr.genti.designsystem.component.item
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import kr.genti.common.extension.noRippleClickable
+import kr.genti.core.designsystem.R
+import kr.genti.designsystem.theme.Disabled
+import kr.genti.designsystem.theme.GentiGreen
+
+@Composable
+fun GentiRatingBar(
+    rating: Int = 5,
+    onRatingChanged: (Int) -> Unit = {},
+) {
+    Row {
+        for (index in 1..5) {
+            Icon(
+                imageVector = ImageVector.vectorResource(R.drawable.ic_star),
+                contentDescription = null,
+                tint = if (index <= rating) GentiGreen else Disabled,
+                modifier = Modifier.noRippleClickable { onRatingChanged(index) }
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewGentiRatingBar() {
+    GentiRatingBar(
+        rating = 3
+    )
+}

--- a/core/designsystem/src/main/res/drawable/ic_star.xml
+++ b/core/designsystem/src/main/res/drawable/ic_star.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="40dp"
+    android:height="40dp"
+    android:viewportWidth="40"
+    android:viewportHeight="40">
+  <path
+      android:pathData="M13.756,32.559C12.243,33.472 10.376,32.117 10.774,30.396L12.417,23.292L6.904,18.512C5.569,17.354 6.281,15.161 8.041,15.008L15.334,14.375L18.158,7.692C18.847,6.064 21.155,6.064 21.843,7.692L24.667,14.375L31.96,15.008C33.721,15.161 34.432,17.354 33.097,18.512L27.584,23.292L29.227,30.396C29.625,32.117 27.759,33.472 26.246,32.559L20.001,28.792L13.756,32.559Z"
+      android:fillColor="#ffffff"/>
+</vector>

--- a/core/navigation/src/main/java/kr/genti/navigation/ResultRoute.kt
+++ b/core/navigation/src/main/java/kr/genti/navigation/ResultRoute.kt
@@ -7,8 +7,15 @@ interface ResultRoute : Route {
     data object Verify : ResultRoute
 
     @Serializable
-    data class Waiting(val isParentPic: Boolean) : ResultRoute
+    data class Waiting(
+        val isParentPic: Boolean
+    ) : ResultRoute
 
     @Serializable
-    data object Finished : ResultRoute
+    data class Finished(
+        val responseId: Long,
+        val imageUrl: String,
+        val isGaro: Boolean,
+        val isParentPic: Boolean
+    ) : ResultRoute
 }

--- a/feature/generate/src/main/java/kr/genti/generate/PromptInputScreen.kt
+++ b/feature/generate/src/main/java/kr/genti/generate/PromptInputScreen.kt
@@ -71,7 +71,10 @@ fun PromptInputScreen(
             GentiCheckedText(text = stringResource(R.string.create_tv_script_subtitle_1))
 
             if (isParentPic) {
-                GentiCheckedText(text = stringResource(R.string.create_tv_script_subtitle_2_parent))
+                GentiCheckedText(
+                    text = stringResource(R.string.create_tv_script_subtitle_2_parent),
+                    modifier = Modifier.padding(horizontal = 16.dp)
+                )
             } else {
                 GentiCheckedText(text = stringResource(R.string.create_tv_script_subtitle_2))
             }

--- a/feature/main/src/main/java/kr/genti/main/MainScreen.kt
+++ b/feature/main/src/main/java/kr/genti/main/MainScreen.kt
@@ -55,8 +55,13 @@ internal fun MainRoute(
                 is MainSideEffect.NavigateToTab -> navigator.navigate(sideEffect.tab)
                 is MainSideEffect.NavigateToVerify -> navigator.navigateToVerify()
                 is MainSideEffect.NavigateToWaiting -> navigator.navigateToWaiting(sideEffect.isParentPic)
-                is MainSideEffect.NavigateToFinished -> navigator.navigateToFinished()
                 is MainSideEffect.NavigateToGenerate -> navigator.navigateToGenerate(sideEffect.isParentPic)
+                is MainSideEffect.NavigateToFinished -> navigator.navigateToFinished(
+                    responseId = sideEffect.responseId,
+                    imageUrl = sideEffect.imageUrl,
+                    isGaro = sideEffect.isGaro,
+                    isParentPic = sideEffect.isParentPic
+                )
             }
         }
     }

--- a/feature/main/src/main/java/kr/genti/main/MainSideEffect.kt
+++ b/feature/main/src/main/java/kr/genti/main/MainSideEffect.kt
@@ -9,5 +9,10 @@ sealed class MainSideEffect {
     data class NavigateToGenerate(val isParentPic: Boolean) : MainSideEffect()
     data object NavigateToVerify : MainSideEffect()
     data class NavigateToWaiting(val isParentPic: Boolean) : MainSideEffect()
-    data object NavigateToFinished: MainSideEffect()
+    data class NavigateToFinished(
+        val responseId: Long,
+        val imageUrl: String,
+        val isGaro: Boolean,
+        val isParentPic: Boolean
+    ) : MainSideEffect()
 }

--- a/feature/main/src/main/java/kr/genti/main/MainViewModel.kt
+++ b/feature/main/src/main/java/kr/genti/main/MainViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kr.genti.common.manager.AmplitudeManager
 import kr.genti.domain.enums.GenerateStatus
+import kr.genti.domain.enums.PictureRatio
 import kr.genti.domain.repository.GenerateRepository
 import kr.genti.main.navigation.MainTab
 import timber.log.Timber
@@ -84,7 +85,14 @@ constructor(
     private fun handleFinishedDialogBtnClick() {
         handleDialogDismiss()
         viewModelScope.launch {
-            _mainSideEffect.emit(MainSideEffect.NavigateToFinished)
+            _mainSideEffect.emit(
+                MainSideEffect.NavigateToFinished(
+                    responseId = mainState.value.generatedImage.response?.responseId ?: -1,
+                    imageUrl = mainState.value.generatedImage.response?.picture?.url ?: "",
+                    isGaro = mainState.value.generatedImage.response?.picture?.pictureRatio == PictureRatio.RATIO_GARO,
+                    isParentPic = mainState.value.generatedImage.paid ?: false
+                )
+            )
         }
     }
 

--- a/feature/main/src/main/java/kr/genti/main/navigation/MainNavigator.kt
+++ b/feature/main/src/main/java/kr/genti/main/navigation/MainNavigator.kt
@@ -20,6 +20,7 @@ import kr.genti.onboarding.navigation.navigateToTutorial
 import kr.genti.profile.navigation.navigateToProfile
 import kr.genti.result.navigation.navigateToVerify
 import kr.genti.result.navigation.navigateToWaiting
+import kr.genti.result.navigation.navigateToFinished
 import kr.genti.setting.navigation.navigateToSetting
 
 class MainNavigator(
@@ -92,9 +93,12 @@ class MainNavigator(
     fun navigateToWaitingWithFinish(isParentPic: Boolean) =
         navController.navigateToWaiting(isParentPic, inclusiveNavOptions)
 
-    fun navigateToFinished() {
-
-    }
+    fun navigateToFinished(
+        responseId: Long,
+        imageUrl: String,
+        isGaro: Boolean,
+        isParentPic: Boolean
+    ) = navController.navigateToFinished(responseId, imageUrl, isGaro, isParentPic)
 
     fun navigateToSplash() = navController.navigateToSplash()
 

--- a/feature/profile/src/main/java/kr/genti/profile/ProfileViewModel.kt
+++ b/feature/profile/src/main/java/kr/genti/profile/ProfileViewModel.kt
@@ -85,7 +85,6 @@ constructor(
     }
 
     private fun handleSaveBtnClick() {
-        updateAmplitude("picdownload", "user_picturedownload")
         viewModelScope.launch {
             if (!checkExternalStoragePermission()) {
                 _profileSideEffect.emit(ProfileSideEffect.StartPermissionLauncher)
@@ -95,6 +94,7 @@ constructor(
                 id = profileState.value.detailImageId,
                 imageUrl = profileState.value.detailImageUrl,
             ).onSuccess {
+                updateAmplitude("picdownload", "user_picturedownload")
                 _profileSideEffect.emit(ProfileSideEffect.ShowDownloadToast)
             }.onFailure {
                 _profileSideEffect.emit(ProfileSideEffect.ShowErrorToast)
@@ -103,12 +103,12 @@ constructor(
     }
 
     private fun handleShareBtnClick() {
-        updateAmplitude("picshare", "user_share")
         viewModelScope.launch {
             ImageManager.getCacheImageUri(
                 id = profileState.value.detailImageId,
                 imageUrl = profileState.value.detailImageUrl,
             ).onSuccess { uri ->
+                updateAmplitude("picshare", "user_share")
                 _profileSideEffect.emit(ProfileSideEffect.NavigateToShare(uri))
             }.onFailure {
                 _profileSideEffect.emit(ProfileSideEffect.ShowErrorToast)

--- a/feature/profile/src/main/java/kr/genti/profile/component/ProfileImagesGridScreen.kt
+++ b/feature/profile/src/main/java/kr/genti/profile/component/ProfileImagesGridScreen.kt
@@ -34,9 +34,7 @@ fun ProfileImagesGridScreen(
 
     LaunchedEffect(gridState) {
         snapshotFlow { gridState.layoutInfo.visibleItemsInfo }
-            .map { visibleItems ->
-                visibleItems.lastOrNull()?.index ?: 0
-            }
+            .map { visibleItems -> visibleItems.lastOrNull()?.index ?: 0 }
             .distinctUntilChanged()
             .collect { lastVisibleItemIndex ->
                 if (lastVisibleItemIndex >= itemList.size - 3) onLastColumnLoaded()
@@ -59,6 +57,7 @@ fun ProfileImagesGridScreen(
         ) { _, item ->
             GentiAsyncImage(
                 url = item.url,
+                isSquare = true,
                 modifier = Modifier.noRippleClickable { onImageItemClick(item) })
         }
         item {

--- a/feature/result/src/main/java/kr/genti/result/component/BackgroundBlurImage.kt
+++ b/feature/result/src/main/java/kr/genti/result/component/BackgroundBlurImage.kt
@@ -21,6 +21,7 @@ import kr.genti.designsystem.theme.Transparent50
 internal fun BackgroundBlurImage(
     modifier: Modifier = Modifier,
     imageUrl: String = "",
+    isGaro: Boolean = false
 ) {
     Box(
         modifier = modifier.fillMaxSize()
@@ -28,7 +29,7 @@ internal fun BackgroundBlurImage(
         val context = LocalContext.current
 
         val imageRequest = ImageRequest.Builder(context)
-            .data(if (LocalInspectionMode.current) R.drawable.mock_img_3_2 else imageUrl)
+            .data(if (LocalInspectionMode.current) if (isGaro) R.drawable.mock_img_2_3 else R.drawable.mock_img_3_2 else imageUrl)
             .build()
 
         Box(modifier = modifier.fillMaxSize()) {
@@ -41,9 +42,11 @@ internal fun BackgroundBlurImage(
                     .blur(radiusX = 50.dp, radiusY = 50.dp)
             )
         }
-        Box(modifier = modifier
-            .fillMaxSize()
-            .background(Transparent50))
+        Box(
+            modifier = modifier
+                .fillMaxSize()
+                .background(Transparent50)
+        )
     }
 }
 

--- a/feature/result/src/main/java/kr/genti/result/component/BackgroundBlurImage.kt
+++ b/feature/result/src/main/java/kr/genti/result/component/BackgroundBlurImage.kt
@@ -1,0 +1,54 @@
+package kr.genti.result.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.blur
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import coil3.request.ImageRequest
+import kr.genti.core.designsystem.R
+import kr.genti.designsystem.theme.Transparent50
+
+@Composable
+internal fun BackgroundBlurImage(
+    modifier: Modifier = Modifier,
+    imageUrl: String = "",
+) {
+    Box(
+        modifier = modifier.fillMaxSize()
+    ) {
+        val context = LocalContext.current
+
+        val imageRequest = ImageRequest.Builder(context)
+            .data(if (LocalInspectionMode.current) R.drawable.mock_img_3_2 else imageUrl)
+            .build()
+
+        Box(modifier = modifier.fillMaxSize()) {
+            AsyncImage(
+                model = imageRequest,
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .blur(radiusX = 50.dp, radiusY = 50.dp)
+            )
+        }
+        Box(modifier = modifier
+            .fillMaxSize()
+            .background(Transparent50))
+    }
+}
+
+@Preview
+@Composable
+private fun BackgroundBlurImagePreview() {
+    BackgroundBlurImage()
+}

--- a/feature/result/src/main/java/kr/genti/result/finished/FinishedIntent.kt
+++ b/feature/result/src/main/java/kr/genti/result/finished/FinishedIntent.kt
@@ -1,13 +1,7 @@
 package kr.genti.result.finished
 
 sealed class FinishedIntent {
-    data class Init(
-        val responseId: Long,
-        val imageUrl: String,
-        val isGaro: Boolean,
-        val isParentPic: Boolean
-    ) : FinishedIntent()
-
+    data class Init(val responseId: Long) : FinishedIntent()
     data object ImageClick : FinishedIntent()
     data object BackButtonClick : FinishedIntent()
     data object ReportButtonClick : FinishedIntent()

--- a/feature/result/src/main/java/kr/genti/result/finished/FinishedIntent.kt
+++ b/feature/result/src/main/java/kr/genti/result/finished/FinishedIntent.kt
@@ -1,0 +1,19 @@
+package kr.genti.result.finished
+
+sealed class FinishedIntent {
+    data class Init(
+        val responseId: Long,
+        val imageUrl: String,
+        val isGaro: Boolean,
+        val isParentPic: Boolean
+    ) : FinishedIntent()
+
+    data object ImageClick : FinishedIntent()
+    data object BackButtonClick : FinishedIntent()
+    data object ReportButtonClick : FinishedIntent()
+    data object ShareButtonClick : FinishedIntent()
+    data object DownloadButtonClick : FinishedIntent()
+    data object ReportDialogButtonClick : FinishedIntent()
+    data object RatingDialogButtonClick : FinishedIntent()
+    data object DialogDismiss : FinishedIntent()
+}

--- a/feature/result/src/main/java/kr/genti/result/finished/FinishedIntent.kt
+++ b/feature/result/src/main/java/kr/genti/result/finished/FinishedIntent.kt
@@ -1,7 +1,7 @@
 package kr.genti.result.finished
 
 sealed class FinishedIntent {
-    data class Init(val responseId: Long) : FinishedIntent()
+    data class Init(val responseId: Long, val isParentPic: Boolean) : FinishedIntent()
     data object ImageClick : FinishedIntent()
     data object BackButtonClick : FinishedIntent()
     data object ReportButtonClick : FinishedIntent()

--- a/feature/result/src/main/java/kr/genti/result/finished/FinishedIntent.kt
+++ b/feature/result/src/main/java/kr/genti/result/finished/FinishedIntent.kt
@@ -11,6 +11,7 @@ sealed class FinishedIntent {
     data class ReportTextChange(val text: String) : FinishedIntent()
     data object ReportSubmitButtonClick : FinishedIntent()
     data object FinishButtonClick : FinishedIntent()
+    data class RatingChange(val rating: Int) : FinishedIntent()
     data object RatingSubmitButtonClick : FinishedIntent()
     data object RatingSkipButtonClick : FinishedIntent()
 }

--- a/feature/result/src/main/java/kr/genti/result/finished/FinishedIntent.kt
+++ b/feature/result/src/main/java/kr/genti/result/finished/FinishedIntent.kt
@@ -1,7 +1,9 @@
 package kr.genti.result.finished
 
 sealed class FinishedIntent {
-    data class Init(val responseId: Long, val isParentPic: Boolean) : FinishedIntent()
+    data class Init(val responseId: Long, val isParentPic: Boolean, val imageUrl: String) :
+        FinishedIntent()
+
     data object ImageClick : FinishedIntent()
     data object BackButtonClick : FinishedIntent()
     data object ReportButtonClick : FinishedIntent()

--- a/feature/result/src/main/java/kr/genti/result/finished/FinishedIntent.kt
+++ b/feature/result/src/main/java/kr/genti/result/finished/FinishedIntent.kt
@@ -7,7 +7,10 @@ sealed class FinishedIntent {
     data object ReportButtonClick : FinishedIntent()
     data object ShareButtonClick : FinishedIntent()
     data object DownloadButtonClick : FinishedIntent()
-    data object ReportDialogButtonClick : FinishedIntent()
-    data object RatingDialogButtonClick : FinishedIntent()
     data object DialogDismiss : FinishedIntent()
+    data class ReportTextChange(val text: String) : FinishedIntent()
+    data object ReportSubmitButtonClick : FinishedIntent()
+    data object FinishButtonClick : FinishedIntent()
+    data object RatingSubmitButtonClick : FinishedIntent()
+    data object RatingSkipButtonClick : FinishedIntent()
 }

--- a/feature/result/src/main/java/kr/genti/result/finished/FinishedScreen.kt
+++ b/feature/result/src/main/java/kr/genti/result/finished/FinishedScreen.kt
@@ -41,6 +41,7 @@ import kr.genti.common.extension.toast
 import kr.genti.core.designsystem.R
 import kr.genti.designsystem.component.button.CloseButton
 import kr.genti.designsystem.component.button.GentiGradationButton
+import kr.genti.designsystem.component.dialog.GentiImageDetailDialog
 import kr.genti.designsystem.component.item.GentiAsyncImage
 import kr.genti.designsystem.theme.Black
 import kr.genti.designsystem.theme.GentiTheme
@@ -92,6 +93,24 @@ internal fun FinishedRoute(
         onShareButtonClick = { viewModel.onIntent(FinishedIntent.ShareButtonClick) },
         onDownloadButtonClick = { viewModel.onIntent(FinishedIntent.DownloadButtonClick) },
     )
+
+    if (finishedState.isDetailDialogVisible) {
+        GentiImageDetailDialog(
+            imageUrl = imageUrl,
+            isGaro = isGaro,
+            isOneButton = true,
+            onSaveBtnClick = { viewModel.onIntent(FinishedIntent.DownloadButtonClick) },
+            onDismissRequest = { viewModel.onIntent(FinishedIntent.DialogDismiss) }
+        )
+    }
+
+    if (finishedState.isReportDialogVisible) {
+
+    }
+
+    if (finishedState.isRatingDialogVisible) {
+
+    }
 }
 
 @Composable

--- a/feature/result/src/main/java/kr/genti/result/finished/FinishedScreen.kt
+++ b/feature/result/src/main/java/kr/genti/result/finished/FinishedScreen.kt
@@ -42,7 +42,9 @@ import kr.genti.core.designsystem.R
 import kr.genti.designsystem.component.button.CloseButton
 import kr.genti.designsystem.component.button.GentiGradationButton
 import kr.genti.designsystem.component.dialog.GentiImageDetailDialog
+import kr.genti.designsystem.component.dialog.GentiTextFieldDialog
 import kr.genti.designsystem.component.item.GentiAsyncImage
+import kr.genti.designsystem.component.layout.GentiLoadingScreen
 import kr.genti.designsystem.theme.Black
 import kr.genti.designsystem.theme.GentiTheme
 import kr.genti.designsystem.theme.Gray
@@ -105,7 +107,14 @@ internal fun FinishedRoute(
     }
 
     if (finishedState.isReportDialogVisible) {
-
+        GentiTextFieldDialog(
+            text = finishedState.reportText,
+            isSubmitted = finishedState.isReportSubmitted,
+            onTextChange = { viewModel.onIntent(FinishedIntent.ReportTextChange(it)) },
+            onSubmitBtnClick = { viewModel.onIntent(FinishedIntent.ReportSubmitButtonClick) },
+            onSubmitFinishBtnClick = { viewModel.onIntent(FinishedIntent.FinishButtonClick) },
+            onDismissRequest = { viewModel.onIntent(FinishedIntent.DialogDismiss) }
+        )
     }
 
     if (finishedState.isRatingDialogVisible) {

--- a/feature/result/src/main/java/kr/genti/result/finished/FinishedScreen.kt
+++ b/feature/result/src/main/java/kr/genti/result/finished/FinishedScreen.kt
@@ -1,5 +1,6 @@
 package kr.genti.result.finished
 
+import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -38,6 +39,9 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kr.genti.common.extension.noRippleClickable
 import kr.genti.common.extension.toast
+import kr.genti.common.manager.ImageManager.getImageChooserIntent
+import kr.genti.common.manager.LauncherManager.rememberPermissionLauncher
+import kr.genti.common.manager.PermissionManager
 import kr.genti.core.designsystem.R
 import kr.genti.designsystem.component.button.CloseButton
 import kr.genti.designsystem.component.button.GentiGradationButton
@@ -65,15 +69,38 @@ internal fun FinishedRoute(
     val lifecycleOwner = LocalLifecycleOwner.current
     val context = LocalContext.current
 
+    val writePermissionLauncher = rememberPermissionLauncher {
+        viewModel.onIntent(FinishedIntent.DownloadButtonClick)
+    }
+
     LaunchedEffect(Unit) {
-        viewModel.onIntent(FinishedIntent.Init(responseId, isParentPic))
+        viewModel.onIntent(FinishedIntent.Init(responseId, isParentPic, imageUrl))
     }
 
     LaunchedEffect(viewModel.finishedSideEffect, lifecycleOwner) {
         viewModel.finishedSideEffect.collect { sideEffect ->
             when (sideEffect) {
                 is FinishedSideEffect.ShowErrorToast -> context.toast(context.getString(R.string.error_msg))
+                is FinishedSideEffect.ShowDownloadToast -> context.toast(context.getString(R.string.profile_image_download_success))
                 is FinishedSideEffect.NavigateToBack -> navigateToBack()
+                is FinishedSideEffect.StartPermissionLauncher -> {
+                    PermissionManager.checkPermissionAndLaunch(
+                        permission = WRITE_EXTERNAL_STORAGE,
+                        context = context,
+                        onPermissionGranted = { viewModel.onIntent(FinishedIntent.DownloadButtonClick) },
+                        onPermissionNotGranted = {
+                            writePermissionLauncher.launch(WRITE_EXTERNAL_STORAGE)
+                        },
+                        onPermissionAlreadyDenied = { intentToSetting ->
+                            context.toast(context.getString(R.string.permission_to_setting))
+                            context.startActivity(intentToSetting)
+                        }
+                    )
+                }
+
+                is FinishedSideEffect.NavigateToShare -> {
+                    context.startActivity(getImageChooserIntent(sideEffect.imageUri))
+                }
             }
         }
     }

--- a/feature/result/src/main/java/kr/genti/result/finished/FinishedScreen.kt
+++ b/feature/result/src/main/java/kr/genti/result/finished/FinishedScreen.kt
@@ -42,9 +42,9 @@ import kr.genti.core.designsystem.R
 import kr.genti.designsystem.component.button.CloseButton
 import kr.genti.designsystem.component.button.GentiGradationButton
 import kr.genti.designsystem.component.dialog.GentiImageDetailDialog
+import kr.genti.designsystem.component.dialog.GentiRatingDialog
 import kr.genti.designsystem.component.dialog.GentiTextFieldDialog
 import kr.genti.designsystem.component.item.GentiAsyncImage
-import kr.genti.designsystem.component.layout.GentiLoadingScreen
 import kr.genti.designsystem.theme.Black
 import kr.genti.designsystem.theme.GentiTheme
 import kr.genti.designsystem.theme.Gray
@@ -118,7 +118,13 @@ internal fun FinishedRoute(
     }
 
     if (finishedState.isRatingDialogVisible) {
-
+        GentiRatingDialog(
+            rating = finishedState.rating,
+            onRatingChange = { viewModel.onIntent(FinishedIntent.RatingChange(it)) },
+            onSubmitBtnClick = { viewModel.onIntent(FinishedIntent.RatingSubmitButtonClick) },
+            onSkipBtnClick = { viewModel.onIntent(FinishedIntent.RatingSkipButtonClick) },
+            onDismissRequest = { viewModel.onIntent(FinishedIntent.DialogDismiss) }
+        )
     }
 }
 

--- a/feature/result/src/main/java/kr/genti/result/finished/FinishedScreen.kt
+++ b/feature/result/src/main/java/kr/genti/result/finished/FinishedScreen.kt
@@ -63,7 +63,7 @@ internal fun FinishedRoute(
     val context = LocalContext.current
 
     LaunchedEffect(Unit) {
-        viewModel.onIntent(FinishedIntent.Init(responseId, imageUrl, isGaro, isParentPic))
+        viewModel.onIntent(FinishedIntent.Init(responseId))
     }
 
     LaunchedEffect(viewModel.finishedSideEffect, lifecycleOwner) {
@@ -82,6 +82,16 @@ internal fun FinishedRoute(
             viewModel.onIntent(FinishedIntent.BackButtonClick)
         }
     }
+
+    FinishedScreen(
+        imageUrl = imageUrl,
+        isParentPic = isParentPic,
+        isGaro = isGaro,
+        onBackButtonClick = { viewModel.onIntent(FinishedIntent.BackButtonClick) },
+        onReportButtonClick = { viewModel.onIntent(FinishedIntent.ReportButtonClick) },
+        onShareButtonClick = { viewModel.onIntent(FinishedIntent.ShareButtonClick) },
+        onDownloadButtonClick = { viewModel.onIntent(FinishedIntent.DownloadButtonClick) },
+    )
 }
 
 @Composable
@@ -91,13 +101,18 @@ private fun FinishedScreen(
     isParentPic: Boolean = false,
     isGaro: Boolean = false,
     onBackButtonClick: () -> Unit = {},
+    onReportButtonClick: () -> Unit = {},
+    onShareButtonClick: () -> Unit = {},
+    onDownloadButtonClick: () -> Unit = {},
 ) {
     Box(
         modifier
             .fillMaxSize()
             .background(Black)
     ) {
-        BackgroundBlurImage(imageUrl = imageUrl)
+        BackgroundBlurImage(
+            imageUrl = imageUrl, isGaro = isGaro
+        )
 
         CloseButton(
             modifier = Modifier.statusBarsPadding(),
@@ -110,6 +125,8 @@ private fun FinishedScreen(
                 .statusBarsPadding()
                 .navigationBarsPadding()
         ) {
+            Spacer(modifier = Modifier.weight(1f))
+
             FinishedTitle(
                 isParentPic = isParentPic
             )
@@ -124,7 +141,12 @@ private fun FinishedScreen(
 
             Spacer(modifier = Modifier.weight(1f))
 
-            FinishedBottomContent()
+            FinishedBottomContent(
+                isParentPic = isParentPic,
+                onReportButtonClick = onReportButtonClick,
+                onShareButtonClick = onShareButtonClick,
+                onDownloadButtonClick = onDownloadButtonClick
+            )
         }
     }
 }
@@ -140,7 +162,7 @@ private fun FinishedTitle(
             .padding(horizontal = 16.dp),
         verticalArrangement = Arrangement.Center
     ) {
-        Spacer(modifier = Modifier.height(70.dp))
+        Spacer(modifier = Modifier.height(40.dp))
         Text(
             text = stringResource(if (!isParentPic) R.string.finished_tv_title else R.string.finished_tv_title_paid),
             style = GentiTheme.typography.title,
@@ -210,17 +232,21 @@ private fun FinishedBottomContent(
             .padding(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        Image(
-            painter = painterResource(R.drawable.img_tooltip_finished),
-            contentDescription = null,
-            modifier = Modifier.width(260.dp)
-        )
+        if (!isParentPic) {
+            Image(
+                painter = painterResource(R.drawable.img_tooltip_finished),
+                contentDescription = null,
+                modifier = Modifier.width(260.dp)
+            )
+        } else {
+            Spacer(modifier = Modifier.height(32.dp))
+        }
 
         Spacer(modifier = Modifier.height(8.dp))
 
         GentiGradationButton(
-            textRes = R.string.btn_share,
-            onClick = onShareButtonClick
+            textRes = if (!isParentPic) R.string.finished_btn_share else R.string.finished_btn_save,
+            onClick = if (!isParentPic) onShareButtonClick else onDownloadButtonClick
         )
 
         Spacer(modifier = Modifier.height(8.dp))

--- a/feature/result/src/main/java/kr/genti/result/finished/FinishedScreen.kt
+++ b/feature/result/src/main/java/kr/genti/result/finished/FinishedScreen.kt
@@ -66,7 +66,7 @@ internal fun FinishedRoute(
     val context = LocalContext.current
 
     LaunchedEffect(Unit) {
-        viewModel.onIntent(FinishedIntent.Init(responseId))
+        viewModel.onIntent(FinishedIntent.Init(responseId, isParentPic))
     }
 
     LaunchedEffect(viewModel.finishedSideEffect, lifecycleOwner) {
@@ -91,6 +91,7 @@ internal fun FinishedRoute(
         isParentPic = isParentPic,
         isGaro = isGaro,
         onBackButtonClick = { viewModel.onIntent(FinishedIntent.BackButtonClick) },
+        onImageClick = { viewModel.onIntent(FinishedIntent.ImageClick) },
         onReportButtonClick = { viewModel.onIntent(FinishedIntent.ReportButtonClick) },
         onShareButtonClick = { viewModel.onIntent(FinishedIntent.ShareButtonClick) },
         onDownloadButtonClick = { viewModel.onIntent(FinishedIntent.DownloadButtonClick) },
@@ -135,6 +136,7 @@ private fun FinishedScreen(
     isParentPic: Boolean = false,
     isGaro: Boolean = false,
     onBackButtonClick: () -> Unit = {},
+    onImageClick: () -> Unit = {},
     onReportButtonClick: () -> Unit = {},
     onShareButtonClick: () -> Unit = {},
     onDownloadButtonClick: () -> Unit = {},
@@ -170,7 +172,9 @@ private fun FinishedScreen(
             FinishedImage(
                 imageUrl = imageUrl,
                 isGaro = isGaro,
-                isParentPic = isParentPic
+                isParentPic = isParentPic,
+                onImageClick = onImageClick,
+                onDownloadButtonClick = onDownloadButtonClick
             )
 
             Spacer(modifier = Modifier.weight(1f))

--- a/feature/result/src/main/java/kr/genti/result/finished/FinishedScreen.kt
+++ b/feature/result/src/main/java/kr/genti/result/finished/FinishedScreen.kt
@@ -1,0 +1,75 @@
+package kr.genti.result.finished
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kr.genti.common.extension.toast
+import kr.genti.core.designsystem.R
+import kr.genti.designsystem.theme.Black
+
+@Composable
+internal fun FinishedRoute(
+    viewModel: FinishedViewModel = hiltViewModel(),
+    responseId: Long = -1,
+    imageUrl: String = "",
+    isGaro: Boolean = false,
+    isParentPic: Boolean = false,
+    navigateToBack: () -> Unit = {},
+) {
+    val finishedState by viewModel.finishedState.collectAsStateWithLifecycle()
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val context = LocalContext.current
+
+    LaunchedEffect(Unit) {
+        viewModel.onIntent(FinishedIntent.Init(responseId, imageUrl, isGaro, isParentPic))
+    }
+
+    LaunchedEffect(viewModel.finishedSideEffect, lifecycleOwner) {
+        viewModel.finishedSideEffect.collect { sideEffect ->
+            when (sideEffect) {
+                is FinishedSideEffect.ShowErrorToast -> context.toast(context.getString(R.string.error_msg))
+                is FinishedSideEffect.NavigateToBack -> navigateToBack()
+            }
+        }
+    }
+
+    BackHandler {
+        if (finishedState.isDetailDialogVisible || finishedState.isRatingDialogVisible || finishedState.isReportDialogVisible) {
+            viewModel.onIntent(FinishedIntent.DialogDismiss)
+        } else {
+            viewModel.onIntent(FinishedIntent.BackButtonClick)
+        }
+    }
+}
+
+@Composable
+private fun FinishedScreen(
+    modifier: Modifier = Modifier,
+    isParentPic: Boolean = false,
+    isGaro: Boolean = false,
+    navigateToBack: () -> Unit = {},
+) {
+    Box(
+        modifier
+            .fillMaxSize()
+            .background(Black)
+    ) {
+
+    }
+}
+
+@Preview
+@Composable
+private fun FinishedScreenPreview() {
+    FinishedScreen(isParentPic = false, isGaro = false)
+}

--- a/feature/result/src/main/java/kr/genti/result/finished/FinishedScreen.kt
+++ b/feature/result/src/main/java/kr/genti/result/finished/FinishedScreen.kt
@@ -1,21 +1,53 @@
 package kr.genti.result.finished
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kr.genti.common.extension.noRippleClickable
 import kr.genti.common.extension.toast
 import kr.genti.core.designsystem.R
+import kr.genti.designsystem.component.button.CloseButton
+import kr.genti.designsystem.component.button.GentiGradationButton
+import kr.genti.designsystem.component.item.GentiAsyncImage
 import kr.genti.designsystem.theme.Black
+import kr.genti.designsystem.theme.GentiTheme
+import kr.genti.designsystem.theme.Gray
+import kr.genti.designsystem.theme.White40
+import kr.genti.designsystem.theme.White60
+import kr.genti.result.component.BackgroundBlurImage
 
 @Composable
 internal fun FinishedRoute(
@@ -55,21 +87,179 @@ internal fun FinishedRoute(
 @Composable
 private fun FinishedScreen(
     modifier: Modifier = Modifier,
+    imageUrl: String = "",
     isParentPic: Boolean = false,
     isGaro: Boolean = false,
-    navigateToBack: () -> Unit = {},
+    onBackButtonClick: () -> Unit = {},
 ) {
     Box(
         modifier
             .fillMaxSize()
             .background(Black)
     ) {
+        BackgroundBlurImage(imageUrl = imageUrl)
 
+        CloseButton(
+            modifier = Modifier.statusBarsPadding(),
+            onCloseBtnClicked = onBackButtonClick
+        )
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .statusBarsPadding()
+                .navigationBarsPadding()
+        ) {
+            FinishedTitle(
+                isParentPic = isParentPic
+            )
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            FinishedImage(
+                imageUrl = imageUrl,
+                isGaro = isGaro,
+                isParentPic = isParentPic
+            )
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            FinishedBottomContent()
+        }
+    }
+}
+
+@Composable
+private fun FinishedTitle(
+    modifier: Modifier = Modifier,
+    isParentPic: Boolean = false,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp),
+        verticalArrangement = Arrangement.Center
+    ) {
+        Spacer(modifier = Modifier.height(70.dp))
+        Text(
+            text = stringResource(if (!isParentPic) R.string.finished_tv_title else R.string.finished_tv_title_paid),
+            style = GentiTheme.typography.title,
+            fontSize = 24.sp,
+            lineHeight = 30.sp,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = stringResource(R.string.finished_tv_saved),
+            style = GentiTheme.typography.body2,
+            color = White60,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+@Composable
+private fun FinishedImage(
+    modifier: Modifier = Modifier,
+    imageUrl: String = "",
+    isGaro: Boolean = false,
+    isParentPic: Boolean = false,
+    onImageClick: () -> Unit = {},
+    onDownloadButtonClick: () -> Unit = {},
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = if (isGaro) 16.dp else 45.dp)
+            .background(Gray, RoundedCornerShape(16.dp))
+            .noRippleClickable { onImageClick() }
+    ) {
+        GentiAsyncImage(
+            url = imageUrl,
+            isGaro = isGaro,
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(16.dp))
+        )
+        if (!isParentPic) {
+            Image(
+                imageVector = ImageVector.vectorResource(R.drawable.ic_download),
+                contentDescription = null,
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(16.dp)
+                    .noRippleClickable { onDownloadButtonClick() }
+            )
+        }
+    }
+}
+
+@Composable
+private fun FinishedBottomContent(
+    modifier: Modifier = Modifier,
+    isParentPic: Boolean = false,
+    onReportButtonClick: () -> Unit = {},
+    onShareButtonClick: () -> Unit = {},
+    onDownloadButtonClick: () -> Unit = {},
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Image(
+            painter = painterResource(R.drawable.img_tooltip_finished),
+            contentDescription = null,
+            modifier = Modifier.width(260.dp)
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        GentiGradationButton(
+            textRes = R.string.btn_share,
+            onClick = onShareButtonClick
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp)
+                .noRippleClickable { onReportButtonClick() },
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = ImageVector.vectorResource(R.drawable.ic_info),
+                contentDescription = null,
+                tint = White40
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = stringResource(R.string.finished_btn_unwanted),
+                style = GentiTheme.typography.body1,
+                color = White60
+            )
+        }
     }
 }
 
 @Preview
 @Composable
 private fun FinishedScreenPreview() {
-    FinishedScreen(isParentPic = false, isGaro = false)
+    GentiTheme {
+        FinishedScreen(isParentPic = false, isGaro = false)
+    }
+}
+
+@Preview
+@Composable
+private fun FinishedScreenParentPreview() {
+    GentiTheme {
+        FinishedScreen(isParentPic = true, isGaro = true)
+    }
 }

--- a/feature/result/src/main/java/kr/genti/result/finished/FinishedSideEffect.kt
+++ b/feature/result/src/main/java/kr/genti/result/finished/FinishedSideEffect.kt
@@ -1,6 +1,11 @@
 package kr.genti.result.finished
 
+import android.net.Uri
+
 sealed class FinishedSideEffect {
     data object ShowErrorToast : FinishedSideEffect()
+    data object ShowDownloadToast : FinishedSideEffect()
     data object NavigateToBack : FinishedSideEffect()
+    data object StartPermissionLauncher : FinishedSideEffect()
+    data class NavigateToShare(val imageUri: Uri) : FinishedSideEffect()
 }

--- a/feature/result/src/main/java/kr/genti/result/finished/FinishedSideEffect.kt
+++ b/feature/result/src/main/java/kr/genti/result/finished/FinishedSideEffect.kt
@@ -1,0 +1,6 @@
+package kr.genti.result.finished
+
+sealed class FinishedSideEffect {
+    data object ShowErrorToast : FinishedSideEffect()
+    data object NavigateToBack : FinishedSideEffect()
+}

--- a/feature/result/src/main/java/kr/genti/result/finished/FinishedState.kt
+++ b/feature/result/src/main/java/kr/genti/result/finished/FinishedState.kt
@@ -2,6 +2,8 @@ package kr.genti.result.finished
 
 data class FinishedState(
     val responseId: Long = -1,
+    val reportText: String = "",
+    val isReportSubmitted: Boolean = false,
     val isDetailDialogVisible: Boolean = false,
     val isReportDialogVisible: Boolean = false,
     val isRatingDialogVisible: Boolean = false,

--- a/feature/result/src/main/java/kr/genti/result/finished/FinishedState.kt
+++ b/feature/result/src/main/java/kr/genti/result/finished/FinishedState.kt
@@ -2,9 +2,6 @@ package kr.genti.result.finished
 
 data class FinishedState(
     val responseId: Long = -1,
-    val imageUrl: String = "",
-    val isGaro: Boolean = false,
-    val isParentPic: Boolean = false,
     val isDetailDialogVisible: Boolean = false,
     val isReportDialogVisible: Boolean = false,
     val isRatingDialogVisible: Boolean = false,

--- a/feature/result/src/main/java/kr/genti/result/finished/FinishedState.kt
+++ b/feature/result/src/main/java/kr/genti/result/finished/FinishedState.kt
@@ -3,6 +3,7 @@ package kr.genti.result.finished
 data class FinishedState(
     val responseId: Long = -1,
     val reportText: String = "",
+    val rating: Int = 5,
     val isReportSubmitted: Boolean = false,
     val isDetailDialogVisible: Boolean = false,
     val isReportDialogVisible: Boolean = false,

--- a/feature/result/src/main/java/kr/genti/result/finished/FinishedState.kt
+++ b/feature/result/src/main/java/kr/genti/result/finished/FinishedState.kt
@@ -3,6 +3,7 @@ package kr.genti.result.finished
 data class FinishedState(
     val responseId: Long = -1,
     val isParentPic: Boolean = false,
+    val imageUrl: String = "",
     val reportText: String = "",
     val rating: Int = 5,
     val isReportSubmitted: Boolean = false,

--- a/feature/result/src/main/java/kr/genti/result/finished/FinishedState.kt
+++ b/feature/result/src/main/java/kr/genti/result/finished/FinishedState.kt
@@ -2,6 +2,7 @@ package kr.genti.result.finished
 
 data class FinishedState(
     val responseId: Long = -1,
+    val isParentPic: Boolean = false,
     val reportText: String = "",
     val rating: Int = 5,
     val isReportSubmitted: Boolean = false,

--- a/feature/result/src/main/java/kr/genti/result/finished/FinishedState.kt
+++ b/feature/result/src/main/java/kr/genti/result/finished/FinishedState.kt
@@ -1,0 +1,11 @@
+package kr.genti.result.finished
+
+data class FinishedState(
+    val responseId: Long = -1,
+    val imageUrl: String = "",
+    val isGaro: Boolean = false,
+    val isParentPic: Boolean = false,
+    val isDetailDialogVisible: Boolean = false,
+    val isReportDialogVisible: Boolean = false,
+    val isRatingDialogVisible: Boolean = false,
+)

--- a/feature/result/src/main/java/kr/genti/result/finished/FinishedViewModel.kt
+++ b/feature/result/src/main/java/kr/genti/result/finished/FinishedViewModel.kt
@@ -1,12 +1,15 @@
 package kr.genti.result.finished
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kr.genti.domain.entity.request.ReportRequestModel
 import kr.genti.domain.repository.GenerateRepository
 import javax.inject.Inject
 
@@ -31,8 +34,11 @@ constructor(
             is FinishedIntent.DialogDismiss -> handleDialogDismiss()
             is FinishedIntent.ShareButtonClick -> handleShareButtonClick()
             is FinishedIntent.DownloadButtonClick -> handleDownloadButtonClick()
-            is FinishedIntent.ReportDialogButtonClick -> handleReportDialogButtonClick()
-            is FinishedIntent.RatingDialogButtonClick -> handleRatingDialogButtonClick()
+            is FinishedIntent.ReportTextChange -> handleReportTextChange(intent.text)
+            is FinishedIntent.ReportSubmitButtonClick -> handleReportSubmitButtonClick()
+            is FinishedIntent.FinishButtonClick -> handleFinishButtonClick()
+            is FinishedIntent.RatingSubmitButtonClick -> handleRatingSubmitButtonClick()
+            is FinishedIntent.RatingSkipButtonClick -> handleRatingSkipButtonClick()
         }
     }
 
@@ -78,11 +84,40 @@ constructor(
 
     }
 
-    private fun handleReportDialogButtonClick() {
+    private fun handleReportTextChange(text: String) {
+        _finishedState.update {
+            it.copy(reportText = text)
+        }
+    }
+
+    private fun handleReportSubmitButtonClick() {
+        viewModelScope.launch {
+            generateRepository.postGenerateReport(
+                ReportRequestModel(
+                    finishedState.value.responseId,
+                    finishedState.value.reportText,
+                ),
+            ).onSuccess {
+                _finishedState.update {
+                    it.copy(isReportSubmitted = true)
+                }
+            }.onFailure {
+                _finishedSideEffect.emit(FinishedSideEffect.ShowErrorToast)
+            }
+        }
+    }
+
+    private fun handleFinishButtonClick() {
+        viewModelScope.launch {
+            _finishedSideEffect.emit(FinishedSideEffect.NavigateToBack)
+        }
+    }
+
+    private fun handleRatingSubmitButtonClick() {
 
     }
 
-    private fun handleRatingDialogButtonClick() {
+    private fun handleRatingSkipButtonClick() {
 
     }
 }

--- a/feature/result/src/main/java/kr/genti/result/finished/FinishedViewModel.kt
+++ b/feature/result/src/main/java/kr/genti/result/finished/FinishedViewModel.kt
@@ -24,7 +24,7 @@ constructor(
 
     fun onIntent(intent: FinishedIntent) {
         when (intent) {
-            is FinishedIntent.Init -> handleInit(intent)
+            is FinishedIntent.Init -> handleInit(intent.responseId)
             is FinishedIntent.ImageClick -> handleImageClick()
             is FinishedIntent.BackButtonClick -> handleBackButtonClick()
             is FinishedIntent.ReportButtonClick -> handleReportButtonClick()
@@ -36,14 +36,9 @@ constructor(
         }
     }
 
-    private fun handleInit(intent: FinishedIntent.Init) {
+    private fun handleInit(responseId: Long) {
         _finishedState.update {
-            it.copy(
-                responseId = intent.responseId,
-                imageUrl = intent.imageUrl,
-                isGaro = intent.isGaro,
-                isParentPic = intent.isParentPic
-            )
+            it.copy(responseId = responseId)
         }
     }
 

--- a/feature/result/src/main/java/kr/genti/result/finished/FinishedViewModel.kt
+++ b/feature/result/src/main/java/kr/genti/result/finished/FinishedViewModel.kt
@@ -11,6 +11,9 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kr.genti.common.manager.AmplitudeManager
 import kr.genti.common.manager.AmplitudeManager.PROPERTY_TYPE
+import kr.genti.common.manager.ImageManager
+import kr.genti.common.manager.ImageManager.checkExternalStoragePermission
+import kr.genti.common.manager.ImageManager.saveImageToStorage
 import kr.genti.domain.entity.request.ReportRequestModel
 import kr.genti.domain.repository.GenerateRepository
 import javax.inject.Inject
@@ -29,7 +32,7 @@ constructor(
 
     fun onIntent(intent: FinishedIntent) {
         when (intent) {
-            is FinishedIntent.Init -> handleInit(intent.responseId, intent.isParentPic)
+            is FinishedIntent.Init -> handleInit(intent)
             is FinishedIntent.ImageClick -> handleImageClick()
             is FinishedIntent.BackButtonClick -> handleBackButtonClick()
             is FinishedIntent.ReportButtonClick -> handleReportButtonClick()
@@ -45,9 +48,13 @@ constructor(
         }
     }
 
-    private fun handleInit(responseId: Long, isParentPic: Boolean) {
+    private fun handleInit(intent: FinishedIntent.Init) {
         _finishedState.update {
-            it.copy(responseId = responseId, isParentPic = isParentPic)
+            it.copy(
+                responseId = intent.responseId,
+                isParentPic = intent.isParentPic,
+                imageUrl = intent.imageUrl
+            )
         }
     }
 
@@ -82,11 +89,35 @@ constructor(
     }
 
     private fun handleShareButtonClick() {
-
+        viewModelScope.launch {
+            ImageManager.getCacheImageUri(
+                id = finishedState.value.responseId,
+                imageUrl = finishedState.value.imageUrl,
+            ).onSuccess { uri ->
+                amplitudeTrackShare()
+                _finishedSideEffect.emit(FinishedSideEffect.NavigateToShare(uri))
+            }.onFailure {
+                _finishedSideEffect.emit(FinishedSideEffect.ShowErrorToast)
+            }
+        }
     }
 
     private fun handleDownloadButtonClick() {
-
+        viewModelScope.launch {
+            if (!checkExternalStoragePermission()) {
+                _finishedSideEffect.emit(FinishedSideEffect.StartPermissionLauncher)
+                return@launch
+            }
+            saveImageToStorage(
+                id = finishedState.value.responseId,
+                imageUrl = finishedState.value.imageUrl,
+            ).onSuccess {
+                amplitudeTrackDownload()
+                _finishedSideEffect.emit(FinishedSideEffect.ShowDownloadToast)
+            }.onFailure {
+                _finishedSideEffect.emit(FinishedSideEffect.ShowErrorToast)
+            }
+        }
     }
 
     private fun handleReportTextChange(text: String) {

--- a/feature/result/src/main/java/kr/genti/result/finished/FinishedViewModel.kt
+++ b/feature/result/src/main/java/kr/genti/result/finished/FinishedViewModel.kt
@@ -37,6 +37,7 @@ constructor(
             is FinishedIntent.ReportTextChange -> handleReportTextChange(intent.text)
             is FinishedIntent.ReportSubmitButtonClick -> handleReportSubmitButtonClick()
             is FinishedIntent.FinishButtonClick -> handleFinishButtonClick()
+            is FinishedIntent.RatingChange -> handleRatingChange(intent.rating)
             is FinishedIntent.RatingSubmitButtonClick -> handleRatingSubmitButtonClick()
             is FinishedIntent.RatingSkipButtonClick -> handleRatingSkipButtonClick()
         }
@@ -113,11 +114,33 @@ constructor(
         }
     }
 
-    private fun handleRatingSubmitButtonClick() {
+    private fun handleRatingChange(rating: Int) {
+        _finishedState.update {
+            it.copy(rating = rating)
+        }
+    }
 
+    private fun handleRatingSubmitButtonClick() {
+        viewModelScope.launch {
+            generateRepository.postGenerateRate(
+                responseId = finishedState.value.responseId.toInt(),
+                star = finishedState.value.rating,
+            ).onSuccess {
+                _finishedSideEffect.emit(FinishedSideEffect.NavigateToBack)
+            }.onFailure {
+                _finishedSideEffect.emit(FinishedSideEffect.ShowErrorToast)
+            }
+        }
     }
 
     private fun handleRatingSkipButtonClick() {
-
+        viewModelScope.launch {
+            generateRepository.postVerifyGenerateState(finishedState.value.responseId.toInt())
+                .onSuccess {
+                    _finishedSideEffect.emit(FinishedSideEffect.NavigateToBack)
+                }.onFailure {
+                    _finishedSideEffect.emit(FinishedSideEffect.ShowErrorToast)
+                }
+        }
     }
 }

--- a/feature/result/src/main/java/kr/genti/result/finished/FinishedViewModel.kt
+++ b/feature/result/src/main/java/kr/genti/result/finished/FinishedViewModel.kt
@@ -1,0 +1,81 @@
+package kr.genti.result.finished
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kr.genti.domain.repository.GenerateRepository
+import javax.inject.Inject
+
+@HiltViewModel
+class FinishedViewModel
+@Inject
+constructor(
+    private val generateRepository: GenerateRepository
+) : ViewModel() {
+    private val _finishedState = MutableStateFlow(FinishedState())
+    val finishedState = _finishedState.asStateFlow()
+
+    private val _finishedSideEffect = MutableSharedFlow<FinishedSideEffect>()
+    val finishedSideEffect = _finishedSideEffect.asSharedFlow()
+
+    fun onIntent(intent: FinishedIntent) {
+        when (intent) {
+            is FinishedIntent.Init -> handleInit(intent)
+            is FinishedIntent.ImageClick -> handleImageClick()
+            is FinishedIntent.BackButtonClick -> handleBackButtonClick()
+            is FinishedIntent.ReportButtonClick -> handleReportButtonClick()
+            is FinishedIntent.ShareButtonClick -> handleShareButtonClick()
+            is FinishedIntent.DownloadButtonClick -> handleDownloadButtonClick()
+            is FinishedIntent.ReportDialogButtonClick -> handleReportDialogButtonClick()
+            is FinishedIntent.RatingDialogButtonClick -> handleRatingDialogButtonClick()
+            is FinishedIntent.DialogDismiss -> handleDialogDismiss()
+        }
+    }
+
+    private fun handleInit(intent: FinishedIntent.Init) {
+        _finishedState.update {
+            it.copy(
+                responseId = intent.responseId,
+                imageUrl = intent.imageUrl,
+                isGaro = intent.isGaro,
+                isParentPic = intent.isParentPic
+            )
+        }
+    }
+
+    private fun handleImageClick() {
+
+    }
+
+    private fun handleBackButtonClick() {
+
+    }
+
+    private fun handleReportButtonClick() {
+
+    }
+
+    private fun handleShareButtonClick() {
+
+    }
+
+    private fun handleDownloadButtonClick() {
+
+    }
+
+    private fun handleReportDialogButtonClick() {
+
+    }
+
+    private fun handleRatingDialogButtonClick() {
+
+    }
+
+    private fun handleDialogDismiss() {
+
+    }
+}

--- a/feature/result/src/main/java/kr/genti/result/finished/FinishedViewModel.kt
+++ b/feature/result/src/main/java/kr/genti/result/finished/FinishedViewModel.kt
@@ -28,11 +28,11 @@ constructor(
             is FinishedIntent.ImageClick -> handleImageClick()
             is FinishedIntent.BackButtonClick -> handleBackButtonClick()
             is FinishedIntent.ReportButtonClick -> handleReportButtonClick()
+            is FinishedIntent.DialogDismiss -> handleDialogDismiss()
             is FinishedIntent.ShareButtonClick -> handleShareButtonClick()
             is FinishedIntent.DownloadButtonClick -> handleDownloadButtonClick()
             is FinishedIntent.ReportDialogButtonClick -> handleReportDialogButtonClick()
             is FinishedIntent.RatingDialogButtonClick -> handleRatingDialogButtonClick()
-            is FinishedIntent.DialogDismiss -> handleDialogDismiss()
         }
     }
 
@@ -43,15 +43,31 @@ constructor(
     }
 
     private fun handleImageClick() {
-
+        _finishedState.update {
+            it.copy(isDetailDialogVisible = true)
+        }
     }
 
     private fun handleBackButtonClick() {
-
+        _finishedState.update {
+            it.copy(isRatingDialogVisible = true)
+        }
     }
 
     private fun handleReportButtonClick() {
+        _finishedState.update {
+            it.copy(isReportDialogVisible = true)
+        }
+    }
 
+    private fun handleDialogDismiss() {
+        _finishedState.update {
+            it.copy(
+                isDetailDialogVisible = false,
+                isReportDialogVisible = false,
+                isRatingDialogVisible = false
+            )
+        }
     }
 
     private fun handleShareButtonClick() {
@@ -67,10 +83,6 @@ constructor(
     }
 
     private fun handleRatingDialogButtonClick() {
-
-    }
-
-    private fun handleDialogDismiss() {
 
     }
 }

--- a/feature/result/src/main/java/kr/genti/result/finished/FinishedViewModel.kt
+++ b/feature/result/src/main/java/kr/genti/result/finished/FinishedViewModel.kt
@@ -9,6 +9,8 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kr.genti.common.manager.AmplitudeManager
+import kr.genti.common.manager.AmplitudeManager.PROPERTY_TYPE
 import kr.genti.domain.entity.request.ReportRequestModel
 import kr.genti.domain.repository.GenerateRepository
 import javax.inject.Inject
@@ -27,7 +29,7 @@ constructor(
 
     fun onIntent(intent: FinishedIntent) {
         when (intent) {
-            is FinishedIntent.Init -> handleInit(intent.responseId)
+            is FinishedIntent.Init -> handleInit(intent.responseId, intent.isParentPic)
             is FinishedIntent.ImageClick -> handleImageClick()
             is FinishedIntent.BackButtonClick -> handleBackButtonClick()
             is FinishedIntent.ReportButtonClick -> handleReportButtonClick()
@@ -43,19 +45,21 @@ constructor(
         }
     }
 
-    private fun handleInit(responseId: Long) {
+    private fun handleInit(responseId: Long, isParentPic: Boolean) {
         _finishedState.update {
-            it.copy(responseId = responseId)
+            it.copy(responseId = responseId, isParentPic = isParentPic)
         }
     }
 
     private fun handleImageClick() {
+        amplitudeTrackEvent("enlarge_picdone_picture")
         _finishedState.update {
             it.copy(isDetailDialogVisible = true)
         }
     }
 
     private fun handleBackButtonClick() {
+        amplitudeTrackEvent("gomain")
         _finishedState.update {
             it.copy(isRatingDialogVisible = true)
         }
@@ -109,6 +113,7 @@ constructor(
     }
 
     private fun handleFinishButtonClick() {
+        amplitudeTrackEvent("reportpic_picdone")
         viewModelScope.launch {
             _finishedSideEffect.emit(FinishedSideEffect.NavigateToBack)
         }
@@ -126,6 +131,7 @@ constructor(
                 responseId = finishedState.value.responseId.toInt(),
                 star = finishedState.value.rating,
             ).onSuccess {
+                amplitudeTrackEvent("ratingsubmit_picdone")
                 _finishedSideEffect.emit(FinishedSideEffect.NavigateToBack)
             }.onFailure {
                 _finishedSideEffect.emit(FinishedSideEffect.ShowErrorToast)
@@ -137,10 +143,40 @@ constructor(
         viewModelScope.launch {
             generateRepository.postVerifyGenerateState(finishedState.value.responseId.toInt())
                 .onSuccess {
+                    amplitudeTrackEvent("ratingpass_picdone")
                     _finishedSideEffect.emit(FinishedSideEffect.NavigateToBack)
                 }.onFailure {
                     _finishedSideEffect.emit(FinishedSideEffect.ShowErrorToast)
                 }
+        }
+    }
+
+    private fun amplitudeTrackEvent(event: String) {
+        AmplitudeManager.trackEvent(
+            event,
+            mapOf(PROPERTY_TYPE to if (finishedState.value.isParentPic) "parents" else "original")
+        )
+    }
+
+    private fun amplitudeTrackDownload() {
+        AmplitudeManager.apply {
+            trackEvent(
+                EVENT_CLICK_BTN,
+                mapOf(PROPERTY_TYPE to if (finishedState.value.isParentPic) "parents" else "original"),
+                mapOf(PROPERTY_BTN to "picdownload")
+            )
+            plusIntProperties("user_picturedownload")
+        }
+    }
+
+    private fun amplitudeTrackShare() {
+        AmplitudeManager.apply {
+            trackEvent(
+                EVENT_CLICK_BTN,
+                mapOf(PROPERTY_TYPE to if (finishedState.value.isParentPic) "parents" else "original"),
+                mapOf(PROPERTY_BTN to "picshare")
+            )
+            plusIntProperties("user_share")
         }
     }
 }

--- a/feature/result/src/main/java/kr/genti/result/navigation/ResultNavigation.kt
+++ b/feature/result/src/main/java/kr/genti/result/navigation/ResultNavigation.kt
@@ -6,6 +6,7 @@ import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
 import kr.genti.navigation.ResultRoute
+import kr.genti.result.finished.FinishedRoute
 import kr.genti.result.verify.VerifyRoute
 import kr.genti.result.waiting.WaitingRoute
 
@@ -22,6 +23,16 @@ fun NavController.navigateToWaiting(
     navigate(ResultRoute.Waiting(isParentPic), navOptions)
 }
 
+fun NavController.navigateToFinished(
+    responseId: Long = -1,
+    imageUrl: String = "",
+    isGaro: Boolean = false,
+    isParentPic: Boolean = false,
+    navOptions: NavOptions? = null
+) {
+    navigate(ResultRoute.Finished(responseId, imageUrl, isGaro, isParentPic), navOptions)
+}
+
 fun NavGraphBuilder.resultNavGraph(
     navigateToBack: () -> Unit = {},
     navigateToBackWithBoolean: (Boolean) -> Unit = {}
@@ -34,6 +45,16 @@ fun NavGraphBuilder.resultNavGraph(
     composable<ResultRoute.Waiting> { backStackEntry ->
         val items = backStackEntry.toRoute<ResultRoute.Waiting>()
         WaitingRoute(
+            isParentPic = items.isParentPic,
+            navigateToBack = navigateToBack
+        )
+    }
+    composable<ResultRoute.Finished> { backStackEntry ->
+        val items = backStackEntry.toRoute<ResultRoute.Finished>()
+        FinishedRoute(
+            responseId = items.responseId,
+            imageUrl = items.imageUrl,
+            isGaro = items.isGaro,
             isParentPic = items.isParentPic,
             navigateToBack = navigateToBack
         )


### PR DESCRIPTION
- closed #233

## *⛳️ Work Description*
- 생성 결과뷰 MVI 구조 구현
- 생성 결과뷰로 네비게이션 시 이미지 정보 포함 이동
- 생성 결과 가로/세로 여부 및 부모님 사진 여부로 UI 분기처리
- 이미지 상세, 오류 제보, 별점 제공 다이얼로그 구현
- 사진 저장 및 공유 로직 구현

## *📸 Screenshot*
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img src="이미지 주소" width=270 /> -->

https://github.com/user-attachments/assets/8052a7aa-219b-4ef3-9aa4-e5a722273b4d

