### PR TITLE
[FEAT/#243] 커스텀 스낵바 설정 및 앱 뒤로가기 대응

### DIFF
--- a/core/common/src/main/java/kr/genti/common/util/DoubleBackHandler.kt
+++ b/core/common/src/main/java/kr/genti/common/util/DoubleBackHandler.kt
@@ -1,0 +1,34 @@
+package kr.genti.common.util
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.navigation.NavController
+
+@Composable
+fun DoubleBackHandler(
+    navController: NavController,
+    timeInterval: Long = 2_000L,
+    onFirstBack: () -> Unit,
+    onSecondBack: () -> Unit
+) {
+    var lastBackTime by remember { mutableLongStateOf(0L) }
+
+    BackHandler {
+        val now = System.currentTimeMillis()
+
+        when {
+            navController.previousBackStackEntry != null -> navController.popBackStack()
+
+            now - lastBackTime >= timeInterval -> {
+                lastBackTime = now
+                onFirstBack()
+            }
+
+            else -> onSecondBack()
+        }
+    }
+}

--- a/core/designsystem/src/main/java/kr/genti/designsystem/component/snackbar/GentiSnackBar.kt
+++ b/core/designsystem/src/main/java/kr/genti/designsystem/component/snackbar/GentiSnackBar.kt
@@ -24,7 +24,7 @@ fun GentiTextSnackBar(message: String) {
         modifier = Modifier
             .fillMaxWidth()
             .wrapContentHeight()
-            .padding(16.dp),
+            .padding(vertical = 22.dp, horizontal = 16.dp)
     ) {
         Box(
             modifier = Modifier

--- a/core/designsystem/src/main/java/kr/genti/designsystem/component/snackbar/GentiSnackBar.kt
+++ b/core/designsystem/src/main/java/kr/genti/designsystem/component/snackbar/GentiSnackBar.kt
@@ -1,0 +1,55 @@
+package kr.genti.designsystem.component.snackbar
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import kr.genti.designsystem.theme.Black
+import kr.genti.designsystem.theme.GentiTheme
+import kr.genti.designsystem.theme.White60
+
+@Composable
+fun GentiTextSnackBar(message: String) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .wrapContentHeight()
+            .padding(16.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .clip(RoundedCornerShape(6.dp))
+                .background(color = White60)
+                .padding(vertical = 14.dp, horizontal = 22.dp)
+        ) {
+            Text(
+                text = message,
+                style = GentiTheme.typography.body2,
+                color = Black,
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .fillMaxWidth()
+                    .padding(2.dp)
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFF030F0F)
+@Composable
+fun GentiTextSnackBarPreview() {
+    GentiTheme {
+        GentiTextSnackBar(message = "스낵바 메세지")
+    }
+}

--- a/core/designsystem/src/main/java/kr/genti/designsystem/component/snackbar/GentiSnackBar.kt
+++ b/core/designsystem/src/main/java/kr/genti/designsystem/component/snackbar/GentiSnackBar.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import kr.genti.designsystem.theme.Black
 import kr.genti.designsystem.theme.GentiTheme
-import kr.genti.designsystem.theme.White60
+import kr.genti.designsystem.theme.White80
 
 @Composable
 fun GentiTextSnackBar(message: String) {
@@ -29,7 +29,7 @@ fun GentiTextSnackBar(message: String) {
         Box(
             modifier = Modifier
                 .clip(RoundedCornerShape(6.dp))
-                .background(color = White60)
+                .background(color = White80)
                 .padding(vertical = 14.dp, horizontal = 22.dp)
         ) {
             Text(

--- a/core/designsystem/src/main/java/kr/genti/designsystem/event/SnackbarTrigger.kt
+++ b/core/designsystem/src/main/java/kr/genti/designsystem/event/SnackbarTrigger.kt
@@ -1,0 +1,7 @@
+package kr.genti.designsystem.event
+
+import androidx.compose.runtime.staticCompositionLocalOf
+
+val LocalSnackBarTrigger = staticCompositionLocalOf<(String) -> Unit> {
+    error("LocalSnackBarTrigger not provided")
+}

--- a/core/designsystem/src/main/java/kr/genti/designsystem/event/SnackbarTrigger.kt
+++ b/core/designsystem/src/main/java/kr/genti/designsystem/event/SnackbarTrigger.kt
@@ -2,6 +2,6 @@ package kr.genti.designsystem.event
 
 import androidx.compose.runtime.staticCompositionLocalOf
 
-val LocalSnackBarTrigger = staticCompositionLocalOf<(String) -> Unit> {
+val LocalSnackBarTrigger = staticCompositionLocalOf<(Int) -> Unit> {
     error("LocalSnackBarTrigger not provided")
 }

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
 
     <string name="error_msg">오류가 발생했습니다. 잠시 후 다시 시도해주세요.</string>
     <string name="permission_to_setting">설정에서 권한에 동의해주세요.</string>
+    <string name="back_pressed_msg">버튼을 한번 더 누르면 종료됩니다.</string>
 
     <string name="default_notification_channel_id">default_messaging_channel</string>
 

--- a/feature/feed/src/main/java/kr/genti/feed/FeedScreen.kt
+++ b/feature/feed/src/main/java/kr/genti/feed/FeedScreen.kt
@@ -20,10 +20,10 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
-import kr.genti.common.extension.toast
 import kr.genti.core.designsystem.R
 import kr.genti.designsystem.component.dialog.GentiBottomSheet
 import kr.genti.designsystem.component.layout.GentiLoadingScreen
+import kr.genti.designsystem.event.LocalSnackBarTrigger
 import kr.genti.designsystem.theme.Black
 import kr.genti.designsystem.theme.GentiTheme
 import kr.genti.domain.entity.response.FeedItemModel
@@ -41,6 +41,7 @@ internal fun FeedRoute(
     val feedState by viewModel.feedState.collectAsStateWithLifecycle()
     val lifecycleOwner = LocalLifecycleOwner.current
     val context = LocalContext.current
+    val showSnackBar = LocalSnackBarTrigger.current
 
     LaunchedEffect(Unit) {
         viewModel.onIntent(FeedIntent.Init)
@@ -49,9 +50,7 @@ internal fun FeedRoute(
     LaunchedEffect(viewModel.feedSideEffect, lifecycleOwner) {
         viewModel.feedSideEffect.collect { sideEffect ->
             when (sideEffect) {
-                is FeedSideEffect.ShowErrorToast -> {
-                    context.toast(context.getString(R.string.error_msg))
-                }
+                is FeedSideEffect.ShowErrorToast -> showSnackBar(R.string.error_msg)
 
                 is FeedSideEffect.NavigateToWebsite -> {
                     context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(sideEffect.url)))

--- a/feature/generate/src/main/java/kr/genti/generate/GenerateRoute.kt
+++ b/feature/generate/src/main/java/kr/genti/generate/GenerateRoute.kt
@@ -38,12 +38,14 @@ import kr.genti.common.manager.LauncherManager.rememberPhotoPickerLauncher
 import kr.genti.core.designsystem.R
 import kr.genti.designsystem.component.layout.GentiLoadingScreen
 import kr.genti.designsystem.component.layout.GentiTopBar
+import kr.genti.designsystem.event.LocalSnackBarTrigger
 import kr.genti.designsystem.theme.Black
 import kr.genti.designsystem.theme.GentiTheme
 import kr.genti.domain.entity.response.ImageFileModel
 import kr.genti.domain.entity.response.PromptExampleModel
 import kr.genti.domain.enums.PictureNumber
 import kr.genti.domain.enums.PictureRatio
+import kr.genti.generate.billing.BillingCallback
 import kr.genti.generate.billing.BillingManager
 import kr.genti.generate.component.GenerateProgressBar
 import kr.genti.generate.model.GenerateStage
@@ -59,27 +61,28 @@ internal fun GenerateRoute(
     val lifecycleOwner = LocalLifecycleOwner.current
     val context = LocalContext.current
     val focusManager = LocalFocusManager.current
+    val showSnackBar = LocalSnackBarTrigger.current
 
     val photoPickerLauncher = rememberPhotoPickerLauncher(maxItems = 3) { uriList ->
         viewModel.onIntent(GenerateIntent.ImageSelect(uriList))
     }
 
     val galleryPickerLauncher = rememberGalleryPickerLauncher { uriList ->
-        if (uriList.size > 3) context.toast(context.getString(R.string.selfie_toast_old_picker_limit))
+        if (uriList.size > 3) showSnackBar(R.string.selfie_toast_old_picker_limit)
         viewModel.onIntent(GenerateIntent.ImageSelect(uriList.take(3)))
     }
 
     val billingManager = remember {
         BillingManager(
             activity = context as Activity,
-            callback = object : kr.genti.generate.billing.BillingCallback {
+            callback = object : BillingCallback {
                 override fun onBillingSuccess(purchase: Purchase) {
                     viewModel.onIntent(GenerateIntent.PurchaseSuccess(purchase))
                 }
 
                 override fun onBillingFailure(responseCode: Int) {
                     viewModel.onIntent(GenerateIntent.PurchaseFailure)
-                    if (responseCode != USER_CANCELED) context.toast(context.getString(R.string.error_msg))
+                    if (responseCode != USER_CANCELED) showSnackBar(R.string.error_msg)
                 }
             },
         )
@@ -96,7 +99,7 @@ internal fun GenerateRoute(
     LaunchedEffect(viewModel.generateSideEffect, lifecycleOwner) {
         viewModel.generateSideEffect.collect { sideEffect ->
             when (sideEffect) {
-                is GenerateSideEffect.ShowErrorToast -> context.toast(context.getString(R.string.error_msg))
+                is GenerateSideEffect.ShowErrorToast -> showSnackBar(R.string.error_msg)
                 is GenerateSideEffect.NavigateToWaiting -> navigateToWaiting(sideEffect.isParentPic)
                 is GenerateSideEffect.NavigateToBack -> navigateToBack()
 

--- a/feature/main/src/main/java/kr/genti/main/MainScreen.kt
+++ b/feature/main/src/main/java/kr/genti/main/MainScreen.kt
@@ -23,7 +23,6 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.launch
-import kr.genti.common.extension.toast
 import kr.genti.core.common.BuildConfig
 import kr.genti.core.designsystem.R
 import kr.genti.designsystem.component.dialog.GentiErrorDialog
@@ -58,7 +57,7 @@ internal fun MainRoute(
 
     val coroutineScope = rememberCoroutineScope()
     val snackBarHostState = remember { SnackbarHostState() }
-    val onShowSnackbar: (String) -> Unit = { text ->
+    val showSnackbar: (String) -> Unit = { text ->
         coroutineScope.launch {
             snackBarHostState.currentSnackbarData?.dismiss()
             snackBarHostState.showSnackbar(text)
@@ -68,8 +67,8 @@ internal fun MainRoute(
     LaunchedEffect(viewModel.mainSideEffect, lifecycleOwner) {
         viewModel.mainSideEffect.collect { sideEffect ->
             when (sideEffect) {
-                is MainSideEffect.ShowErrorToast -> context.toast(context.getString(R.string.error_msg))
-                is MainSideEffect.ShowStatusChangedToast -> context.toast(context.getString(R.string.toast_state_changed))
+                is MainSideEffect.ShowErrorToast -> showSnackbar(context.getString(R.string.error_msg))
+                is MainSideEffect.ShowStatusChangedToast -> showSnackbar(context.getString(R.string.toast_state_changed))
                 is MainSideEffect.NavigateToTab -> navigator.navigate(sideEffect.tab)
                 is MainSideEffect.NavigateToVerify -> navigator.navigateToVerify()
                 is MainSideEffect.NavigateToWaiting -> navigator.navigateToWaiting(sideEffect.isParentPic)
@@ -100,7 +99,7 @@ internal fun MainRoute(
         currentGenerateStatus = mainState.currentGenerateStatus,
         isPreview = isPreview,
         snackBarHostState = snackBarHostState,
-        onShowSnackbar = onShowSnackbar,
+        onShowSnackbar = showSnackbar,
         onTabSelected = { tab -> viewModel.onIntent(MainIntent.TabSelect(tab)) },
         onGenerateBtnClicked = { viewModel.onIntent(MainIntent.GenerateBtnClick) },
         onDebugPatchBtnClicked = { viewModel.onIntent(MainIntent.DebugPatchBtnClick) }

--- a/feature/main/src/main/java/kr/genti/main/MainScreen.kt
+++ b/feature/main/src/main/java/kr/genti/main/MainScreen.kt
@@ -44,6 +44,7 @@ internal fun MainRoute(
     val mainState by viewModel.mainState.collectAsStateWithLifecycle()
     val lifecycleOwner = LocalLifecycleOwner.current
     val context = LocalContext.current
+    val isPreview = LocalInspectionMode.current
 
     val verifyResult by navigator.verifyResultFlow.collectAsState()
 
@@ -79,6 +80,7 @@ internal fun MainRoute(
 
     MainScreen(
         navigator = navigator,
+        isPreview = isPreview,
         currentGenerateStatus = mainState.currentGenerateStatus,
         onTabSelected = { tab -> viewModel.onIntent(MainIntent.TabSelect(tab)) },
         onGenerateBtnClicked = { viewModel.onIntent(MainIntent.GenerateBtnClick) },
@@ -129,6 +131,7 @@ internal fun MainRoute(
 private fun MainScreen(
     modifier: Modifier = Modifier,
     navigator: MainNavigator = rememberMainNavigator(),
+    isPreview: Boolean = true,
     currentGenerateStatus: GenerateStatus = GenerateStatus.EMPTY,
     onTabSelected: (MainTab) -> Unit = {},
     onGenerateBtnClicked: () -> Unit = {},
@@ -140,14 +143,14 @@ private fun MainScreen(
         Scaffold(
             bottomBar = {
                 MainBottomBar(
-                    visible = LocalInspectionMode.current || navigator.shouldShowBottomBar(),
+                    visible = isPreview || navigator.shouldShowBottomBar(),
                     tabs = MainTab.entries.toImmutableList(),
                     currentTab = navigator.currentTab,
                     onTabSelected = onTabSelected
                 )
             },
             content = { paddingValues ->
-                if (LocalInspectionMode.current) {
+                if (isPreview) {
                     Box(
                         modifier = Modifier
                             .fillMaxSize()
@@ -165,13 +168,13 @@ private fun MainScreen(
         )
 
         GenerateForceButton(
-            isVisible = BuildConfig.DEBUG && currentGenerateStatus == GenerateStatus.IN_PROGRESS && (LocalInspectionMode.current || navigator.shouldShowBottomBar()),
+            isVisible = BuildConfig.DEBUG && currentGenerateStatus == GenerateStatus.IN_PROGRESS && (isPreview || navigator.shouldShowBottomBar()),
             onDebugPatchBtnClicked = onDebugPatchBtnClicked,
             modifier = Modifier.align(Alignment.BottomCenter)
         )
 
         MainBottomBtn(
-            visible = LocalInspectionMode.current || navigator.shouldShowBottomBar(),
+            visible = isPreview || navigator.shouldShowBottomBar(),
             onButtonClick = onGenerateBtnClicked,
             modifier = Modifier.align(Alignment.BottomCenter)
         )

--- a/feature/main/src/main/java/kr/genti/main/MainScreen.kt
+++ b/feature/main/src/main/java/kr/genti/main/MainScreen.kt
@@ -4,10 +4,15 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -17,12 +22,15 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.launch
 import kr.genti.common.extension.toast
 import kr.genti.core.common.BuildConfig
 import kr.genti.core.designsystem.R
 import kr.genti.designsystem.component.dialog.GentiErrorDialog
 import kr.genti.designsystem.component.dialog.GentiNotiDialog
 import kr.genti.designsystem.component.dialog.GentiWarningDialog
+import kr.genti.designsystem.component.snackbar.GentiTextSnackBar
+import kr.genti.designsystem.event.LocalSnackBarTrigger
 import kr.genti.designsystem.theme.Black
 import kr.genti.designsystem.theme.GentiTheme
 import kr.genti.domain.enums.GenerateStatus
@@ -47,6 +55,15 @@ internal fun MainRoute(
     val isPreview = LocalInspectionMode.current
 
     val verifyResult by navigator.verifyResultFlow.collectAsState()
+
+    val coroutineScope = rememberCoroutineScope()
+    val snackBarHostState = remember { SnackbarHostState() }
+    val onShowSnackbar: (String) -> Unit = { text ->
+        coroutineScope.launch {
+            snackBarHostState.currentSnackbarData?.dismiss()
+            snackBarHostState.showSnackbar(text)
+        }
+    }
 
     LaunchedEffect(viewModel.mainSideEffect, lifecycleOwner) {
         viewModel.mainSideEffect.collect { sideEffect ->
@@ -80,8 +97,10 @@ internal fun MainRoute(
 
     MainScreen(
         navigator = navigator,
-        isPreview = isPreview,
         currentGenerateStatus = mainState.currentGenerateStatus,
+        isPreview = isPreview,
+        snackBarHostState = snackBarHostState,
+        onShowSnackbar = onShowSnackbar,
         onTabSelected = { tab -> viewModel.onIntent(MainIntent.TabSelect(tab)) },
         onGenerateBtnClicked = { viewModel.onIntent(MainIntent.GenerateBtnClick) },
         onDebugPatchBtnClicked = { viewModel.onIntent(MainIntent.DebugPatchBtnClick) }
@@ -131,41 +150,53 @@ internal fun MainRoute(
 private fun MainScreen(
     modifier: Modifier = Modifier,
     navigator: MainNavigator = rememberMainNavigator(),
-    isPreview: Boolean = true,
     currentGenerateStatus: GenerateStatus = GenerateStatus.EMPTY,
+    isPreview: Boolean = LocalInspectionMode.current,
+    snackBarHostState: SnackbarHostState = remember { SnackbarHostState() },
+    onShowSnackbar: (String) -> Unit = {},
     onTabSelected: (MainTab) -> Unit = {},
     onGenerateBtnClicked: () -> Unit = {},
     onDebugPatchBtnClicked: () -> Unit = {}
 ) {
+
     Box(
         modifier.fillMaxSize()
     ) {
-        Scaffold(
-            bottomBar = {
-                MainBottomBar(
-                    visible = isPreview || navigator.shouldShowBottomBar(),
-                    tabs = MainTab.entries.toImmutableList(),
-                    currentTab = navigator.currentTab,
-                    onTabSelected = onTabSelected
-                )
-            },
-            content = { paddingValues ->
-                if (isPreview) {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .background(Black)
+        CompositionLocalProvider(
+            LocalSnackBarTrigger provides onShowSnackbar,
+        ) {
+            Scaffold(
+                snackbarHost = {
+                    SnackbarHost(hostState = snackBarHostState) {
+                        GentiTextSnackBar(it.visuals.message)
+                    }
+                },
+                bottomBar = {
+                    MainBottomBar(
+                        visible = isPreview || navigator.shouldShowBottomBar(),
+                        tabs = MainTab.entries.toImmutableList(),
+                        currentTab = navigator.currentTab,
+                        onTabSelected = onTabSelected
                     )
-                } else {
-                    MainNavHost(
-                        paddingValues = paddingValues,
-                        navigator = navigator,
-                        modifier = Modifier.background(Black),
-                        startNavigateToGenerate = onGenerateBtnClicked
-                    )
+                },
+                content = { paddingValues ->
+                    if (isPreview) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .background(Black)
+                        )
+                    } else {
+                        MainNavHost(
+                            paddingValues = paddingValues,
+                            navigator = navigator,
+                            modifier = Modifier.background(Black),
+                            startNavigateToGenerate = onGenerateBtnClicked
+                        )
+                    }
                 }
-            }
-        )
+            )
+        }
 
         GenerateForceButton(
             isVisible = BuildConfig.DEBUG && currentGenerateStatus == GenerateStatus.IN_PROGRESS && (isPreview || navigator.shouldShowBottomBar()),

--- a/feature/main/src/main/java/kr/genti/main/MainScreen.kt
+++ b/feature/main/src/main/java/kr/genti/main/MainScreen.kt
@@ -1,5 +1,8 @@
 package kr.genti.main
 
+import kotlinx.coroutines.withTimeoutOrNull
+import androidx.compose.material3.SnackbarDuration
+
 import android.app.Activity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -23,6 +26,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kr.genti.common.util.DoubleBackHandler
 import kr.genti.core.common.BuildConfig
@@ -62,9 +66,9 @@ internal fun MainRoute(
     val showSnackBar: (Int) -> Unit = { resId ->
         coroutineScope.launch {
             snackBarHostState.currentSnackbarData?.dismiss()
-            snackBarHostState.showSnackbar(
-                message = context.getString(resId)
-            )
+            withTimeoutOrNull(2_000L) {
+                snackBarHostState.showSnackbar(context.getString(resId))
+            }
         }
     }
 

--- a/feature/main/src/main/java/kr/genti/main/MainScreen.kt
+++ b/feature/main/src/main/java/kr/genti/main/MainScreen.kt
@@ -1,5 +1,6 @@
 package kr.genti.main
 
+import android.app.Activity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -23,6 +24,7 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.launch
+import kr.genti.common.util.DoubleBackHandler
 import kr.genti.core.common.BuildConfig
 import kr.genti.core.designsystem.R
 import kr.genti.designsystem.component.dialog.GentiErrorDialog
@@ -65,6 +67,12 @@ internal fun MainRoute(
             )
         }
     }
+
+    DoubleBackHandler(
+        navController = navigator.navController,
+        onFirstBack = { showSnackBar(R.string.back_pressed_msg) },
+        onSecondBack = { (context as Activity).finish() }
+    )
 
     LaunchedEffect(viewModel.mainSideEffect, lifecycleOwner) {
         viewModel.mainSideEffect.collect { sideEffect ->

--- a/feature/main/src/main/java/kr/genti/main/MainScreen.kt
+++ b/feature/main/src/main/java/kr/genti/main/MainScreen.kt
@@ -57,18 +57,20 @@ internal fun MainRoute(
 
     val coroutineScope = rememberCoroutineScope()
     val snackBarHostState = remember { SnackbarHostState() }
-    val showSnackbar: (String) -> Unit = { text ->
+    val showSnackBar: (Int) -> Unit = { resId ->
         coroutineScope.launch {
             snackBarHostState.currentSnackbarData?.dismiss()
-            snackBarHostState.showSnackbar(text)
+            snackBarHostState.showSnackbar(
+                message = context.getString(resId)
+            )
         }
     }
 
     LaunchedEffect(viewModel.mainSideEffect, lifecycleOwner) {
         viewModel.mainSideEffect.collect { sideEffect ->
             when (sideEffect) {
-                is MainSideEffect.ShowErrorToast -> showSnackbar(context.getString(R.string.error_msg))
-                is MainSideEffect.ShowStatusChangedToast -> showSnackbar(context.getString(R.string.toast_state_changed))
+                is MainSideEffect.ShowErrorToast -> showSnackBar(R.string.error_msg)
+                is MainSideEffect.ShowStatusChangedToast -> showSnackBar(R.string.toast_state_changed)
                 is MainSideEffect.NavigateToTab -> navigator.navigate(sideEffect.tab)
                 is MainSideEffect.NavigateToVerify -> navigator.navigateToVerify()
                 is MainSideEffect.NavigateToWaiting -> navigator.navigateToWaiting(sideEffect.isParentPic)
@@ -99,7 +101,7 @@ internal fun MainRoute(
         currentGenerateStatus = mainState.currentGenerateStatus,
         isPreview = isPreview,
         snackBarHostState = snackBarHostState,
-        onShowSnackbar = showSnackbar,
+        onShowSnackBar = showSnackBar,
         onTabSelected = { tab -> viewModel.onIntent(MainIntent.TabSelect(tab)) },
         onGenerateBtnClicked = { viewModel.onIntent(MainIntent.GenerateBtnClick) },
         onDebugPatchBtnClicked = { viewModel.onIntent(MainIntent.DebugPatchBtnClick) }
@@ -152,7 +154,7 @@ private fun MainScreen(
     currentGenerateStatus: GenerateStatus = GenerateStatus.EMPTY,
     isPreview: Boolean = LocalInspectionMode.current,
     snackBarHostState: SnackbarHostState = remember { SnackbarHostState() },
-    onShowSnackbar: (String) -> Unit = {},
+    onShowSnackBar: (Int) -> Unit = {},
     onTabSelected: (MainTab) -> Unit = {},
     onGenerateBtnClicked: () -> Unit = {},
     onDebugPatchBtnClicked: () -> Unit = {}
@@ -162,7 +164,7 @@ private fun MainScreen(
         modifier.fillMaxSize()
     ) {
         CompositionLocalProvider(
-            LocalSnackBarTrigger provides onShowSnackbar,
+            LocalSnackBarTrigger provides onShowSnackBar,
         ) {
             Scaffold(
                 snackbarHost = {

--- a/feature/onboarding/src/main/java/kr/genti/onboarding/login/LoginScreen.kt
+++ b/feature/onboarding/src/main/java/kr/genti/onboarding/login/LoginScreen.kt
@@ -26,6 +26,7 @@ import com.kakao.sdk.user.UserApiClient
 import kr.genti.common.extension.toast
 import kr.genti.core.designsystem.R
 import kr.genti.designsystem.component.layout.GentiLoadingScreen
+import kr.genti.designsystem.event.LocalSnackBarTrigger
 import kr.genti.designsystem.theme.GentiTheme
 import kr.genti.designsystem.theme.White80
 import kr.genti.onboarding.component.KakaoLoginButton
@@ -40,6 +41,7 @@ internal fun LoginRoute(
     val loginState by viewModel.loginState.collectAsStateWithLifecycle()
     val lifecycleOwner = LocalLifecycleOwner.current
     val context = LocalContext.current
+    val showSnackBar = LocalSnackBarTrigger.current
 
     LaunchedEffect(Unit) {
         viewModel.onIntent(
@@ -50,7 +52,7 @@ internal fun LoginRoute(
     LaunchedEffect(viewModel.loginSideEffect, lifecycleOwner) {
         viewModel.loginSideEffect.collect { sideEffect ->
             when (sideEffect) {
-                is LoginSideEffect.ShowErrorToast -> context.toast(context.getString(R.string.error_msg))
+                is LoginSideEffect.ShowErrorToast -> showSnackBar(R.string.error_msg)
 
                 is LoginSideEffect.NavigateToSignup -> navigateToSignup()
 

--- a/feature/onboarding/src/main/java/kr/genti/onboarding/signup/SignupScreen.kt
+++ b/feature/onboarding/src/main/java/kr/genti/onboarding/signup/SignupScreen.kt
@@ -38,11 +38,11 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kr.genti.common.extension.noRippleClickable
-import kr.genti.common.extension.toast
 import kr.genti.core.designsystem.R
 import kr.genti.designsystem.component.button.GentiButton
 import kr.genti.designsystem.component.button.GentiSelectButton
 import kr.genti.designsystem.component.layout.GentiLoadingScreen
+import kr.genti.designsystem.event.LocalSnackBarTrigger
 import kr.genti.designsystem.theme.Black
 import kr.genti.designsystem.theme.GentiGradationEnd
 import kr.genti.designsystem.theme.GentiGradationStart
@@ -60,8 +60,8 @@ internal fun SignupRoute(
 ) {
     val signupState by viewModel.signupState.collectAsStateWithLifecycle()
     val lifecycleOwner = LocalLifecycleOwner.current
-    val context = LocalContext.current
     val focusManager = LocalFocusManager.current
+    val showSnackBar = LocalSnackBarTrigger.current
 
     LaunchedEffect(Unit) {
         viewModel.onIntent(SignupIntent.Init)
@@ -70,7 +70,7 @@ internal fun SignupRoute(
     LaunchedEffect(viewModel.signupSideEffect, lifecycleOwner) {
         viewModel.signupSideEffect.collect { sideEffect ->
             when (sideEffect) {
-                is SignupSideEffect.ShowErrorToast -> context.toast(context.getString(R.string.error_msg))
+                is SignupSideEffect.ShowErrorToast -> showSnackBar(R.string.error_msg)
                 is SignupSideEffect.NavigateToTutorial -> navigateToTutorial()
             }
         }

--- a/feature/onboarding/src/main/java/kr/genti/onboarding/splash/SplashScreen.kt
+++ b/feature/onboarding/src/main/java/kr/genti/onboarding/splash/SplashScreen.kt
@@ -22,6 +22,7 @@ import kr.genti.common.extension.toast
 import kr.genti.common.manager.AppUpdateManager
 import kr.genti.common.manager.LauncherManager.rememberIntentSenderLauncher
 import kr.genti.core.designsystem.R
+import kr.genti.designsystem.event.LocalSnackBarTrigger
 import kr.genti.designsystem.theme.GentiTheme
 
 @Composable
@@ -32,6 +33,7 @@ internal fun SplashRoute(
 ) {
     val lifecycleOwner = LocalLifecycleOwner.current
     val context = LocalContext.current
+    val showSnackBar = LocalSnackBarTrigger.current
 
     val launcher = rememberIntentSenderLauncher { isAppUpdateSuccess ->
         viewModel.onIntent(SplashIntent.AppUpdateFinish(isAppUpdateSuccess))
@@ -44,7 +46,7 @@ internal fun SplashRoute(
     LaunchedEffect(viewModel.splashSideEffect, lifecycleOwner) {
         viewModel.splashSideEffect.collect { sideEffect ->
             when (sideEffect) {
-                is SplashSideEffect.ShowErrorToast -> context.toast(context.getString(R.string.error_msg))
+                is SplashSideEffect.ShowErrorToast -> showSnackBar(R.string.error_msg)
                 is SplashSideEffect.NavigateToLogin -> navigateToLogin()
                 is SplashSideEffect.NavigateToFeed -> navigateToFeed()
                 is SplashSideEffect.StartAppUpdate -> AppUpdateManager.startAppUpdate(launcher)

--- a/feature/profile/src/main/java/kr/genti/profile/ProfileScreen.kt
+++ b/feature/profile/src/main/java/kr/genti/profile/ProfileScreen.kt
@@ -29,6 +29,7 @@ import kr.genti.common.manager.PermissionManager
 import kr.genti.core.designsystem.R
 import kr.genti.designsystem.component.dialog.GentiImageDetailDialog
 import kr.genti.designsystem.component.layout.GentiLoadingScreen
+import kr.genti.designsystem.event.LocalSnackBarTrigger
 import kr.genti.designsystem.theme.Black
 import kr.genti.designsystem.theme.GentiTheme
 import kr.genti.domain.entity.response.ImageModel
@@ -48,6 +49,7 @@ internal fun ProfileRoute(
     val profileState by viewModel.profileState.collectAsStateWithLifecycle()
     val lifecycleOwner = LocalLifecycleOwner.current
     val context = LocalContext.current
+    val showSnackBar = LocalSnackBarTrigger.current
 
     val writePermissionLauncher = rememberPermissionLauncher {
         viewModel.onIntent(ProfileIntent.SaveBtnClick)
@@ -60,8 +62,8 @@ internal fun ProfileRoute(
     LaunchedEffect(viewModel.profileSideEffect, lifecycleOwner) {
         viewModel.profileSideEffect.collect { sideEffect ->
             when (sideEffect) {
-                is ProfileSideEffect.ShowErrorToast -> context.toast(context.getString(R.string.error_msg))
                 is ProfileSideEffect.ShowDownloadToast -> context.toast(context.getString(R.string.profile_image_download_success))
+                is ProfileSideEffect.ShowErrorToast -> showSnackBar(R.string.error_msg)
                 is ProfileSideEffect.NavigateToGenerate -> navigateToGenerate()
                 is ProfileSideEffect.NavigateToSetting -> navigateToSetting()
 

--- a/feature/result/src/main/java/kr/genti/result/finished/FinishedScreen.kt
+++ b/feature/result/src/main/java/kr/genti/result/finished/FinishedScreen.kt
@@ -49,6 +49,7 @@ import kr.genti.designsystem.component.dialog.GentiImageDetailDialog
 import kr.genti.designsystem.component.dialog.GentiRatingDialog
 import kr.genti.designsystem.component.dialog.GentiTextFieldDialog
 import kr.genti.designsystem.component.item.GentiAsyncImage
+import kr.genti.designsystem.event.LocalSnackBarTrigger
 import kr.genti.designsystem.theme.Black
 import kr.genti.designsystem.theme.GentiTheme
 import kr.genti.designsystem.theme.Gray
@@ -68,6 +69,7 @@ internal fun FinishedRoute(
     val finishedState by viewModel.finishedState.collectAsStateWithLifecycle()
     val lifecycleOwner = LocalLifecycleOwner.current
     val context = LocalContext.current
+    val showSnackBar = LocalSnackBarTrigger.current
 
     val writePermissionLauncher = rememberPermissionLauncher {
         viewModel.onIntent(FinishedIntent.DownloadButtonClick)
@@ -80,8 +82,8 @@ internal fun FinishedRoute(
     LaunchedEffect(viewModel.finishedSideEffect, lifecycleOwner) {
         viewModel.finishedSideEffect.collect { sideEffect ->
             when (sideEffect) {
-                is FinishedSideEffect.ShowErrorToast -> context.toast(context.getString(R.string.error_msg))
                 is FinishedSideEffect.ShowDownloadToast -> context.toast(context.getString(R.string.profile_image_download_success))
+                is FinishedSideEffect.ShowErrorToast -> showSnackBar(R.string.error_msg)
                 is FinishedSideEffect.NavigateToBack -> navigateToBack()
                 is FinishedSideEffect.StartPermissionLauncher -> {
                     PermissionManager.checkPermissionAndLaunch(

--- a/feature/result/src/main/java/kr/genti/result/verify/VerifyRoute.kt
+++ b/feature/result/src/main/java/kr/genti/result/verify/VerifyRoute.kt
@@ -17,6 +17,7 @@ import kr.genti.common.manager.LauncherManager.rememberPermissionLauncher
 import kr.genti.common.manager.PermissionManager.checkPermissionAndLaunch
 import kr.genti.core.designsystem.R
 import kr.genti.designsystem.component.dialog.GentiWarningDialog
+import kr.genti.designsystem.event.LocalSnackBarTrigger
 
 @Composable
 internal fun VerifyRoute(
@@ -26,6 +27,7 @@ internal fun VerifyRoute(
     val verifyState by viewModel.verifyState.collectAsStateWithLifecycle()
     val lifecycleOwner = LocalLifecycleOwner.current
     val context = LocalContext.current
+    val showSnackBar = LocalSnackBarTrigger.current
 
     val cameraPermissionLauncher = rememberPermissionLauncher {
         viewModel.onIntent(VerifyIntent.CameraPermissionGrant)
@@ -40,7 +42,7 @@ internal fun VerifyRoute(
     LaunchedEffect(viewModel.verifySideEffect, lifecycleOwner) {
         viewModel.verifySideEffect.collect { sideEffect ->
             when (sideEffect) {
-                is VerifySideEffect.ShowErrorToast -> context.toast(context.getString(R.string.error_msg))
+                is VerifySideEffect.ShowErrorToast -> showSnackBar(R.string.error_msg)
 
                 is VerifySideEffect.NavigateToBack -> navigateToBack(false)
 

--- a/feature/setting/src/main/java/kr/genti/setting/SettingScreen.kt
+++ b/feature/setting/src/main/java/kr/genti/setting/SettingScreen.kt
@@ -23,10 +23,10 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.jakewharton.processphoenix.ProcessPhoenix
-import kr.genti.common.extension.toast
 import kr.genti.core.designsystem.R
 import kr.genti.designsystem.component.dialog.GentiWarningDialog
 import kr.genti.designsystem.component.layout.GentiTopBar
+import kr.genti.designsystem.event.LocalSnackBarTrigger
 import kr.genti.designsystem.theme.Black
 import kr.genti.designsystem.theme.GentiGreen
 import kr.genti.designsystem.theme.GentiTheme
@@ -43,11 +43,12 @@ internal fun SettingRoute(
     val settingState by viewModel.settingState.collectAsStateWithLifecycle()
     val lifecycleOwner = LocalLifecycleOwner.current
     val context = LocalContext.current
+    val showSnackBar = LocalSnackBarTrigger.current
 
     LaunchedEffect(viewModel.settingSideEffect, lifecycleOwner) {
         viewModel.settingSideEffect.collect { sideEffect ->
             when (sideEffect) {
-                is SettingSideEffect.ShowErrorToast -> context.toast(context.getString(R.string.error_msg))
+                is SettingSideEffect.ShowErrorToast -> showSnackBar(R.string.error_msg)
 
                 is SettingSideEffect.NavigateToBack -> navigateToBack()
 


### PR DESCRIPTION
- closed #243

## *⛳️ Work Description*
- 정리 : https://marchbreeze.notion.site/CompositionLocal-SnackbarHostState-1edb6895dba980b6afdedc214403b541?pvs=4
- 커스텀 스낵바 설정 및 기존 토스트 전환 (지속시간 2초)
- 앱 두번 뒤로가기 눌러야 종료되도록 구현

## *📸 Screenshot*
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img src="이미지 주소" width=270 /> -->

https://github.com/user-attachments/assets/1b08e4af-b4e8-4fc7-8068-ac3ee82bc902


