### PR TITLE
[FEAT/#245] 네트워크 상태 모니터링 및 PullToRefresh 재시도 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="com.android.vending.BILLING" />

--- a/core/common/src/main/java/kr/genti/common/manager/NetworkMonitorManager.kt
+++ b/core/common/src/main/java/kr/genti/common/manager/NetworkMonitorManager.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.flow.StateFlow
 object NetworkMonitorManager {
     private lateinit var connectivityManager: ConnectivityManager
 
-    private val _isConnected = MutableStateFlow(false)
+    private val _isConnected = MutableStateFlow(true)
     val isConnected: StateFlow<Boolean> = _isConnected
 
     private val networkRequest = NetworkRequest.Builder()

--- a/core/common/src/main/java/kr/genti/common/manager/NetworkMonitorManager.kt
+++ b/core/common/src/main/java/kr/genti/common/manager/NetworkMonitorManager.kt
@@ -1,0 +1,47 @@
+package kr.genti.common.manager
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+object NetworkMonitorManager {
+    private lateinit var connectivityManager: ConnectivityManager
+
+    private val _isConnected = MutableStateFlow(false)
+    val isConnected: StateFlow<Boolean> = _isConnected
+
+    private val networkRequest = NetworkRequest.Builder()
+        .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+        .build()
+
+    private val networkCallback = object : ConnectivityManager.NetworkCallback() {
+        override fun onAvailable(network: Network) {
+            _isConnected.value = true
+        }
+
+        override fun onLost(network: Network) {
+            _isConnected.value = false
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    fun registerNetworkCallback(context: Context) {
+        connectivityManager = context
+            .getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+
+        connectivityManager.registerNetworkCallback(networkRequest, networkCallback)
+
+        _isConnected.value = connectivityManager.activeNetwork
+            ?.let(connectivityManager::getNetworkCapabilities)
+            ?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) == true
+    }
+
+    fun unRegisterNetworkCallback() {
+        connectivityManager.unregisterNetworkCallback(networkCallback)
+    }
+}

--- a/core/designsystem/src/main/java/kr/genti/designsystem/component/layout/GentiPullToRefreshBox.kt
+++ b/core/designsystem/src/main/java/kr/genti/designsystem/component/layout/GentiPullToRefreshBox.kt
@@ -1,0 +1,41 @@
+package kr.genti.designsystem.component.layout
+
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults.Indicator
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import kr.genti.designsystem.theme.Gray
+import kr.genti.designsystem.theme.White80
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun GentiPullToRefreshBox(
+    modifier: Modifier = Modifier,
+    isRefreshing: Boolean = false,
+    onRefresh: () -> Unit = {},
+    content: @Composable BoxScope.() -> Unit = {}
+) {
+    val refreshState = rememberPullToRefreshState()
+
+    PullToRefreshBox(
+        modifier = modifier,
+        isRefreshing = isRefreshing,
+        state = refreshState,
+        onRefresh = onRefresh,
+        indicator = {
+            Indicator(
+                modifier = Modifier.align(Alignment.TopCenter),
+                isRefreshing = isRefreshing,
+                containerColor = White80,
+                color = Gray,
+                state = refreshState
+            )
+        }
+    ) {
+        content()
+    }
+}

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -178,6 +178,9 @@
     <string name="unable_tv_title">현재 점검 중입니다!</string>
     <string name="unable_tv_subtitle">09.30 22시까지 사진 생성이 불가능합니다.\n금방 돌아오겠습니다.</string>
 
+    <string name="network_tv_title">네트워크가 불안정합니다.</string>
+    <string name="network_tv_subtitle">네트워크 상태를 확인한 후, 다시 시도해주세요.</string>
+
     <string name="toast_state_changed">사진 강제 생성이 요청되었어요.</string>
 
 </resources>

--- a/feature/feed/src/main/java/kr/genti/feed/FeedIntent.kt
+++ b/feature/feed/src/main/java/kr/genti/feed/FeedIntent.kt
@@ -2,6 +2,7 @@ package kr.genti.feed
 
 sealed class FeedIntent {
     data object Init: FeedIntent()
+    data object Refresh: FeedIntent()
     data object InfoBtnClick: FeedIntent()
     data object TooltipClick: FeedIntent()
     data object ListScroll: FeedIntent()

--- a/feature/feed/src/main/java/kr/genti/feed/FeedScreen.kt
+++ b/feature/feed/src/main/java/kr/genti/feed/FeedScreen.kt
@@ -7,9 +7,6 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.pulltorefresh.PullToRefreshBox
-import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults.Indicator
-import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -25,11 +22,10 @@ import kotlinx.collections.immutable.persistentListOf
 import kr.genti.core.designsystem.R
 import kr.genti.designsystem.component.dialog.GentiBottomSheet
 import kr.genti.designsystem.component.layout.GentiLoadingScreen
+import kr.genti.designsystem.component.layout.GentiPullToRefreshBox
 import kr.genti.designsystem.event.LocalSnackBarTrigger
 import kr.genti.designsystem.theme.Black
 import kr.genti.designsystem.theme.GentiTheme
-import kr.genti.designsystem.theme.Gray
-import kr.genti.designsystem.theme.White80
 import kr.genti.domain.entity.response.FeedItemModel
 import kr.genti.domain.entity.response.ImageModel
 import kr.genti.domain.enums.PictureRatio
@@ -88,7 +84,6 @@ internal fun FeedRoute(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun FeedScreen(
     modifier: Modifier = Modifier,
@@ -103,21 +98,9 @@ private fun FeedScreen(
     onTooltipClick: () -> Unit = {},
     onListScroll: () -> Unit = {}
 ) {
-    val refreshState = rememberPullToRefreshState()
-
-    PullToRefreshBox(
+    GentiPullToRefreshBox(
         isRefreshing = isRefreshing,
-        state = refreshState,
         onRefresh = onRefresh,
-        indicator = {
-            Indicator(
-                modifier = Modifier.align(Alignment.TopCenter),
-                isRefreshing = isRefreshing,
-                containerColor = White80,
-                color = Gray,
-                state = refreshState
-            )
-        },
         modifier = modifier
             .fillMaxSize()
             .background(Black)

--- a/feature/feed/src/main/java/kr/genti/feed/FeedScreen.kt
+++ b/feature/feed/src/main/java/kr/genti/feed/FeedScreen.kt
@@ -3,11 +3,13 @@ package kr.genti.feed
 import android.content.Intent
 import android.net.Uri
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults.Indicator
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -26,6 +28,8 @@ import kr.genti.designsystem.component.layout.GentiLoadingScreen
 import kr.genti.designsystem.event.LocalSnackBarTrigger
 import kr.genti.designsystem.theme.Black
 import kr.genti.designsystem.theme.GentiTheme
+import kr.genti.designsystem.theme.Gray
+import kr.genti.designsystem.theme.White80
 import kr.genti.domain.entity.response.FeedItemModel
 import kr.genti.domain.entity.response.ImageModel
 import kr.genti.domain.enums.PictureRatio
@@ -63,9 +67,11 @@ internal fun FeedRoute(
         modifier = Modifier,
         paddingValues = paddingValues,
         itemList = feedState.itemList,
+        isRefreshing = feedState.isRefreshing,
         isTooltipVisible = feedState.isTooltipVisible,
         isTooltipClosed = feedState.isTooltipClosed,
         isLoading = feedState.isLoading,
+        onRefresh = { viewModel.onIntent(FeedIntent.Refresh) },
         onInfoBtnClick = { viewModel.onIntent(FeedIntent.InfoBtnClick) },
         onTooltipClick = { viewModel.onIntent(FeedIntent.TooltipClick) },
         onListScroll = { viewModel.onIntent(FeedIntent.ListScroll) }
@@ -82,19 +88,36 @@ internal fun FeedRoute(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun FeedScreen(
     modifier: Modifier = Modifier,
     paddingValues: PaddingValues = PaddingValues(),
     itemList: ImmutableList<FeedItemModel> = persistentListOf(),
+    isRefreshing: Boolean = false,
     isTooltipVisible: Boolean = false,
     isTooltipClosed: Boolean = false,
     isLoading: Boolean = false,
+    onRefresh: () -> Unit = {},
     onInfoBtnClick: () -> Unit = {},
     onTooltipClick: () -> Unit = {},
     onListScroll: () -> Unit = {}
 ) {
-    Box(
+    val refreshState = rememberPullToRefreshState()
+
+    PullToRefreshBox(
+        isRefreshing = isRefreshing,
+        state = refreshState,
+        onRefresh = onRefresh,
+        indicator = {
+            Indicator(
+                modifier = Modifier.align(Alignment.TopCenter),
+                isRefreshing = isRefreshing,
+                containerColor = White80,
+                color = Gray,
+                state = refreshState
+            )
+        },
         modifier = modifier
             .fillMaxSize()
             .background(Black)

--- a/feature/feed/src/main/java/kr/genti/feed/FeedState.kt
+++ b/feature/feed/src/main/java/kr/genti/feed/FeedState.kt
@@ -6,6 +6,7 @@ import kr.genti.domain.entity.response.FeedItemModel
 
 data class FeedState(
     val itemList: ImmutableList<FeedItemModel> = persistentListOf(),
+    val isRefreshing: Boolean = false,
     val isTooltipVisible: Boolean = false,
     val isTooltipClosed: Boolean = false,
     val isBottomSheetVisible: Boolean = false,

--- a/feature/feed/src/main/java/kr/genti/feed/FeedViewModel.kt
+++ b/feature/feed/src/main/java/kr/genti/feed/FeedViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -29,6 +30,7 @@ constructor(
     fun onIntent(intent: FeedIntent) {
         when (intent) {
             is FeedIntent.Init -> handleInit()
+            is FeedIntent.Refresh -> handleRefresh()
             is FeedIntent.InfoBtnClick -> handleInfoBtnClick()
             is FeedIntent.TooltipClick -> handleTooltipClick()
             is FeedIntent.ListScroll -> handleListScroll()
@@ -42,6 +44,18 @@ constructor(
             changeLoadingState(true)
             getExamplePromptsFromServer()
             changeLoadingState(false)
+            _feedState.update {
+                it.copy(isRefreshing = false)
+            }
+        }
+    }
+
+    private fun handleRefresh() {
+        viewModelScope.launch {
+            _feedState.update { it.copy(isRefreshing = true) }
+            getExamplePromptsFromServer()
+            delay(1_000)
+            _feedState.update { it.copy(isRefreshing = false) }
         }
     }
 

--- a/feature/feed/src/main/java/kr/genti/feed/FeedViewModel.kt
+++ b/feature/feed/src/main/java/kr/genti/feed/FeedViewModel.kt
@@ -44,9 +44,6 @@ constructor(
             changeLoadingState(true)
             getExamplePromptsFromServer()
             changeLoadingState(false)
-            _feedState.update {
-                it.copy(isRefreshing = false)
-            }
         }
     }
 
@@ -54,7 +51,7 @@ constructor(
         viewModelScope.launch {
             _feedState.update { it.copy(isRefreshing = true) }
             getExamplePromptsFromServer()
-            delay(1_000)
+            delay(500)
             _feedState.update { it.copy(isRefreshing = false) }
         }
     }

--- a/feature/main/src/main/java/kr/genti/main/MainIntent.kt
+++ b/feature/main/src/main/java/kr/genti/main/MainIntent.kt
@@ -6,6 +6,7 @@ sealed class MainIntent {
     data class TabSelect(val tab: MainTab) : MainIntent()
     data object GenerateBtnClick : MainIntent()
     data class PushAlarmReceived(val type: String?) : MainIntent()
+    data class NetworkChangeMonitored(val isConnected: Boolean) : MainIntent()
     data object DialogDismiss : MainIntent()
     data object RegenerateDialogBtnClick : MainIntent()
     data object FinishedDialogBtnClick : MainIntent()

--- a/feature/main/src/main/java/kr/genti/main/MainScreen.kt
+++ b/feature/main/src/main/java/kr/genti/main/MainScreen.kt
@@ -1,8 +1,5 @@
 package kr.genti.main
 
-import kotlinx.coroutines.withTimeoutOrNull
-import androidx.compose.material3.SnackbarDuration
-
 import android.app.Activity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -26,8 +23,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.collections.immutable.toImmutableList
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import kr.genti.common.util.DoubleBackHandler
 import kr.genti.core.common.BuildConfig
 import kr.genti.core.designsystem.R

--- a/feature/main/src/main/java/kr/genti/main/MainScreen.kt
+++ b/feature/main/src/main/java/kr/genti/main/MainScreen.kt
@@ -9,8 +9,8 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -25,6 +25,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
+import kr.genti.common.manager.NetworkMonitorManager
 import kr.genti.common.util.DoubleBackHandler
 import kr.genti.core.common.BuildConfig
 import kr.genti.core.designsystem.R
@@ -56,7 +57,8 @@ internal fun MainRoute(
     val context = LocalContext.current
     val isPreview = LocalInspectionMode.current
 
-    val verifyResult by navigator.verifyResultFlow.collectAsState()
+    val verifyResult by navigator.verifyResultFlow.collectAsStateWithLifecycle()
+    val isNetworkConnected by NetworkMonitorManager.isConnected.collectAsStateWithLifecycle()
 
     val coroutineScope = rememberCoroutineScope()
     val snackBarHostState = remember { SnackbarHostState() }
@@ -103,6 +105,15 @@ internal fun MainRoute(
             viewModel.onIntent(MainIntent.GenerateBtnClick)
             navigator.removeBackStackEntry()
         }
+    }
+
+    DisposableEffect(context) {
+        NetworkMonitorManager.registerNetworkCallback(context)
+        onDispose { NetworkMonitorManager.unRegisterNetworkCallback() }
+    }
+
+    LaunchedEffect(isNetworkConnected) {
+        viewModel.onIntent(MainIntent.NetworkChangeMonitored(isNetworkConnected))
     }
 
     MainScreen(

--- a/feature/main/src/main/java/kr/genti/main/MainScreen.kt
+++ b/feature/main/src/main/java/kr/genti/main/MainScreen.kt
@@ -165,6 +165,16 @@ internal fun MainRoute(
             onDismissRequest = { viewModel.onIntent(MainIntent.DialogDismiss) },
         )
     }
+
+    if (mainState.isNetworkDialogVisible) {
+        GentiWarningDialog(
+            titleRes = R.string.network_tv_title,
+            subtitleRes = R.string.network_tv_subtitle,
+            btnTextRes = R.string.btn_close,
+            isOneButton = true,
+            onDismissRequest = { viewModel.onIntent(MainIntent.DialogDismiss) }
+        )
+    }
 }
 
 @Composable

--- a/feature/main/src/main/java/kr/genti/main/MainState.kt
+++ b/feature/main/src/main/java/kr/genti/main/MainState.kt
@@ -13,4 +13,5 @@ data class MainState(
     val isErrorDialogVisible: Boolean = false,
     val isUnableDialogVisible: Boolean = false,
     val isSelectDialogVisible: Boolean = false,
+    val isNetworkDialogVisible: Boolean = false
 )

--- a/feature/main/src/main/java/kr/genti/main/MainViewModel.kt
+++ b/feature/main/src/main/java/kr/genti/main/MainViewModel.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.launch
 import kr.genti.common.manager.AmplitudeManager
 import kr.genti.domain.enums.GenerateStatus
 import kr.genti.domain.enums.PictureRatio
-import kr.genti.domain.repository.GenerateRepository
 import kr.genti.domain.usecase.generate.CheckServerAvailableUseCase
 import kr.genti.domain.usecase.result.ForceGenerateInDebugUseCase
 import kr.genti.domain.usecase.result.GetCurrentGenerateStatusUseCase
@@ -43,6 +42,7 @@ constructor(
             is MainIntent.TabSelect -> handleTabClick(intent.tab)
             is MainIntent.GenerateBtnClick -> handleGenerateBtnClick()
             is MainIntent.PushAlarmReceived -> handlePushAlarmReceived(intent.type)
+            is MainIntent.NetworkChangeMonitored -> handleNetworkChangeMonitored(intent.isConnected)
             is MainIntent.DialogDismiss -> handleDialogDismiss()
             is MainIntent.RegenerateDialogBtnClick -> handleRegenerateDialogBtnClick()
             is MainIntent.FinishedDialogBtnClick -> handleFinishedDialogBtnClick()
@@ -68,6 +68,12 @@ constructor(
         if (type == TYPE_SUCCESS || type == TYPE_CANCELED) handleGenerateBtnClick()
     }
 
+    private fun handleNetworkChangeMonitored(isConnected: Boolean) {
+        _mainState.update {
+            it.copy(isNetworkDialogVisible = !isConnected)
+        }
+    }
+
     private fun handleDialogDismiss() {
         viewModelScope.launch {
             _mainState.update {
@@ -75,7 +81,8 @@ constructor(
                     isErrorDialogVisible = false,
                     isUnableDialogVisible = false,
                     isFinishedDialogVisible = false,
-                    isSelectDialogVisible = false
+                    isSelectDialogVisible = false,
+                    isNetworkDialogVisible = false
                 )
             }
             if (mainState.value.currentGenerateStatus == GenerateStatus.CANCELED) {

--- a/feature/profile/src/main/java/kr/genti/profile/ProfileIntent.kt
+++ b/feature/profile/src/main/java/kr/genti/profile/ProfileIntent.kt
@@ -4,6 +4,7 @@ import kr.genti.domain.entity.response.ImageModel
 
 sealed class ProfileIntent {
     data object Init: ProfileIntent()
+    data object Refresh: ProfileIntent()
     data class ImageItemClick(val item: ImageModel): ProfileIntent()
     data object GenerateBtnClick: ProfileIntent()
     data object SettingBtnClick: ProfileIntent()

--- a/feature/profile/src/main/java/kr/genti/profile/ProfileScreen.kt
+++ b/feature/profile/src/main/java/kr/genti/profile/ProfileScreen.kt
@@ -29,6 +29,7 @@ import kr.genti.common.manager.PermissionManager
 import kr.genti.core.designsystem.R
 import kr.genti.designsystem.component.dialog.GentiImageDetailDialog
 import kr.genti.designsystem.component.layout.GentiLoadingScreen
+import kr.genti.designsystem.component.layout.GentiPullToRefreshBox
 import kr.genti.designsystem.event.LocalSnackBarTrigger
 import kr.genti.designsystem.theme.Black
 import kr.genti.designsystem.theme.GentiTheme
@@ -92,8 +93,10 @@ internal fun ProfileRoute(
     ProfileScreen(
         paddingValues = paddingValues,
         itemList = profileState.itemList,
+        isRefreshing = profileState.isRefreshing,
         isLoading = profileState.isLoading,
         isGenerating = profileState.isGenerating,
+        onRefresh = { viewModel.onIntent(ProfileIntent.Refresh) },
         onImageItemClick = { viewModel.onIntent(ProfileIntent.ImageItemClick(it)) },
         onGenerateBtnClick = { viewModel.onIntent(ProfileIntent.GenerateBtnClick) },
         onSettingBtnClick = { viewModel.onIntent(ProfileIntent.SettingBtnClick) },
@@ -117,18 +120,22 @@ private fun ProfileScreen(
     modifier: Modifier = Modifier,
     paddingValues: PaddingValues = PaddingValues(),
     itemList: ImmutableList<ImageModel> = persistentListOf(),
+    isRefreshing: Boolean = false,
     isLoading: Boolean = false,
     isGenerating: Boolean = false,
+    onRefresh: () -> Unit = {},
     onImageItemClick: (ImageModel) -> Unit = {},
     onGenerateBtnClick: () -> Unit = {},
     onSettingBtnClick: () -> Unit = {},
     onLastColumnLoaded: () -> Unit = {}
 ) {
-    Box(
+    GentiPullToRefreshBox(
+        isRefreshing = isRefreshing,
+        onRefresh = onRefresh,
         modifier = modifier
             .fillMaxSize()
             .background(Black)
-            .padding(bottom = paddingValues.calculateBottomPadding()),
+            .padding(bottom = paddingValues.calculateBottomPadding())
     ) {
         Column(
             Modifier

--- a/feature/profile/src/main/java/kr/genti/profile/ProfileState.kt
+++ b/feature/profile/src/main/java/kr/genti/profile/ProfileState.kt
@@ -15,4 +15,5 @@ data class ProfileState(
     val isDetailDialogShown: Boolean = false,
     val isGenerating: Boolean = false,
     val isLoading: Boolean = false,
+    val isRefreshing: Boolean = false
 )

--- a/feature/profile/src/main/java/kr/genti/profile/ProfileViewModel.kt
+++ b/feature/profile/src/main/java/kr/genti/profile/ProfileViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -37,6 +38,7 @@ constructor(
     fun onIntent(intent: ProfileIntent) {
         when (intent) {
             is ProfileIntent.Init -> handleInit()
+            is ProfileIntent.Refresh -> handleRefresh()
             is ProfileIntent.ImageItemClick -> handleImageItemClick(intent.item)
             is ProfileIntent.GenerateBtnClick -> handleGenerateBtnClick()
             is ProfileIntent.SettingBtnClick -> handleSettingBtnClick()
@@ -53,6 +55,16 @@ constructor(
             getGenerateStatusFromServer()
             getPictureListFromServer()
             changeLoadingState(false)
+        }
+    }
+
+    private fun handleRefresh() {
+        viewModelScope.launch {
+            _profileState.update { it.copy(isRefreshing = true) }
+            getGenerateStatusFromServer()
+            getPictureListFromServer()
+            delay(500)
+            _profileState.update { it.copy(isRefreshing = false) }
         }
     }
 


### PR DESCRIPTION
- closed #245

## *⛳️ Work Description*
- ConnectivityManager를 활용해서 네트워크 상태 감지 및 알림 다이얼로그 설정
- PullToRefreshBox를 활용해서 당겨서 리스트 새로고침 구현

## *📸 Screenshot*
<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img src="이미지 주소" width=270 /> -->

https://github.com/user-attachments/assets/7e4fd113-0d6f-4d35-bc6f-8eaf1b046fa9


## *📢 To Reviewers*
- 참고 : https://marchbreeze.notion.site/Pull-to-Refresh-1edb6895dba980b1b1e0c84f6f97494d?pvs=4
